### PR TITLE
Implement parsing module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,12 @@
  * @module
  */
 
-export type { EmailAddress } from "./types.ts";
+export type {
+  Attachment,
+  EmailAddress,
+  ParsedEmail,
+  ThreadingHeaders,
+} from "./types.ts";
 
 export {
   deduplicateAddresses,
@@ -28,3 +33,5 @@ export {
   parseAddress,
   parseAddressList,
 } from "./addressing.ts";
+
+export { extractThreadingHeaders, parseMessage } from "./parsing.ts";

--- a/src/parsing.test.ts
+++ b/src/parsing.test.ts
@@ -1,0 +1,622 @@
+import { describe, expect, it } from "vitest";
+
+import { extractThreadingHeaders, parseMessage } from "./parsing.ts";
+
+function eml(lines: ReadonlyArray<string>): string {
+  return lines.join("\r\n");
+}
+
+describe("parseMessage — plain text", () => {
+  it("parses a minimal text-only email", async () => {
+    const raw = eml([
+      "From: Ada <ada@example.com>",
+      "To: grace@example.com",
+      "Subject: Hello",
+      "Message-ID: <abc@example.com>",
+      "Date: Mon, 19 Apr 2026 12:00:00 +0000",
+      "",
+      "Body text here.",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.subject).toBe("Hello");
+    expect(email.from).toEqual({ name: "Ada", address: "ada@example.com" });
+    expect(email.to).toEqual([{ address: "grace@example.com" }]);
+    expect(email.text?.trim()).toBe("Body text here.");
+    expect(email.html).toBeUndefined();
+    expect(email.messageId).toBe("<abc@example.com>");
+    expect(email.date instanceof Date).toBe(true);
+    expect(email.date?.toISOString()).toBe("2026-04-19T12:00:00.000Z");
+  });
+});
+
+describe("parseMessage — empty-collection invariants", () => {
+  it("returns empty arrays for missing to/cc/bcc/references/attachments", async () => {
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: Lonely",
+      "",
+      "Body",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.to).toEqual([]);
+    expect(email.cc).toEqual([]);
+    expect(email.bcc).toEqual([]);
+    expect(email.references).toEqual([]);
+    expect(email.attachments).toEqual([]);
+  });
+});
+
+describe("parseMessage — threading headers", () => {
+  it("splits the References header on whitespace", async () => {
+    const raw = eml([
+      "From: ada@example.com",
+      "To: grace@example.com",
+      "Subject: Re: Hi",
+      "In-Reply-To: <parent@example.com>",
+      "References: <root@example.com> <middle@example.com> <parent@example.com>",
+      "",
+      "reply body",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.inReplyTo).toBe("<parent@example.com>");
+    expect(email.references).toEqual([
+      "<root@example.com>",
+      "<middle@example.com>",
+      "<parent@example.com>",
+    ]);
+  });
+
+  it("handles folded References across multiple lines", async () => {
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: Re: Hi",
+      "References: <root@example.com>",
+      "\t<middle@example.com>",
+      " <parent@example.com>",
+      "",
+      "body",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.references).toEqual([
+      "<root@example.com>",
+      "<middle@example.com>",
+      "<parent@example.com>",
+    ]);
+  });
+
+  it("handles a single-token References header", async () => {
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: Re: Hi",
+      "References: <only@example.com>",
+      "",
+      "body",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.references).toEqual(["<only@example.com>"]);
+  });
+
+  it("preserves every token of a very long References chain", async () => {
+    const ids = Array.from({ length: 50 }, (_, i) => `<id${i}@example.com>`);
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: Re: long",
+      `References: ${ids.join(" ")}`,
+      "",
+      "body",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.references).toHaveLength(50);
+    expect(email.references[0]).toBe("<id0@example.com>");
+    expect(email.references[49]).toBe("<id49@example.com>");
+  });
+});
+
+describe("parseMessage — dates", () => {
+  it("returns undefined for an unparseable Date header", async () => {
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: Bad date",
+      "Date: not a real date at all",
+      "",
+      "body",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.date).toBeUndefined();
+  });
+
+  it("returns undefined when the Date header is absent", async () => {
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: No date",
+      "",
+      "body",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.date).toBeUndefined();
+  });
+});
+
+describe("parseMessage — headers map", () => {
+  it("preserves every Received header in order across a long chain", async () => {
+    const hops = Array.from(
+      { length: 12 },
+      (_, i) => `Received: from hop${12 - i}.example.com by hop${11 - i}.example.com`,
+    );
+    const raw = eml([
+      ...hops,
+      "From: ada@example.com",
+      "Subject: Many hops",
+      "",
+      "body",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    const received = email.headers.get("received");
+
+    expect(received).toHaveLength(12);
+    expect(received?.[0]).toContain("hop12.example.com");
+    expect(received?.[11]).toContain("hop1.example.com");
+  });
+
+  it("preserves multiple DKIM-Signature headers", async () => {
+    const raw = eml([
+      "DKIM-Signature: v=1; a=rsa-sha256; d=original.example.com",
+      "DKIM-Signature: v=1; a=rsa-sha256; d=listserv.example.com",
+      "From: ada@example.com",
+      "Subject: Signed twice",
+      "",
+      "body",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    const sigs = email.headers.get("dkim-signature");
+
+    expect(sigs).toHaveLength(2);
+    expect(sigs?.[0]).toContain("original.example.com");
+    expect(sigs?.[1]).toContain("listserv.example.com");
+  });
+
+  it("stores header keys lowercased", async () => {
+    const raw = eml([
+      "X-Custom-Header: value",
+      "From: ada@example.com",
+      "Subject: Hi",
+      "",
+      "body",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.headers.get("x-custom-header")).toEqual(["value"]);
+    expect(email.headers.has("X-Custom-Header")).toBe(false);
+  });
+});
+
+describe("parseMessage — addresses", () => {
+  it("flattens group syntax in To", async () => {
+    const raw = eml([
+      "From: ada@example.com",
+      "To: Team: alice@example.com, bob@example.com;",
+      "Subject: Group",
+      "",
+      "body",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.to).toEqual([
+      { address: "alice@example.com" },
+      { address: "bob@example.com" },
+    ]);
+  });
+
+  it("decodes RFC 2047 Q-encoded display names in From", async () => {
+    const raw = eml([
+      "From: =?UTF-8?Q?Ada_Lovelace?= <ada@example.com>",
+      "Subject: Encoded",
+      "",
+      "body",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.from).toEqual({
+      name: "Ada Lovelace",
+      address: "ada@example.com",
+    });
+  });
+
+  it("decodes RFC 2047 B-encoded display names in From (non-ASCII)", async () => {
+    // Base64 of "Äda Lovelace" (UTF-8): "w4RkYSBMb3ZlbGFjZQ=="
+    const raw = eml([
+      "From: =?UTF-8?B?w4RkYSBMb3ZlbGFjZQ==?= <ada@example.com>",
+      "Subject: Encoded",
+      "",
+      "body",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.from).toEqual({
+      name: "Äda Lovelace",
+      address: "ada@example.com",
+    });
+  });
+
+  it("picks the first member when From uses group syntax", async () => {
+    const raw = eml([
+      "From: Team: ada@example.com, grace@example.com;",
+      "Subject: Group From",
+      "",
+      "body",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.from).toEqual({ address: "ada@example.com" });
+  });
+
+  it("picks the first replyTo when multiple are present", async () => {
+    const raw = eml([
+      "From: ada@example.com",
+      "Reply-To: primary@example.com, secondary@example.com",
+      "Subject: Reply",
+      "",
+      "body",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.replyTo).toEqual({ address: "primary@example.com" });
+  });
+});
+
+describe("parseMessage — HTML and multipart", () => {
+  it("extracts HTML when present", async () => {
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: HTML",
+      "Content-Type: text/html; charset=utf-8",
+      "",
+      "<p>Hello <b>world</b></p>",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.html?.trim()).toContain("<p>Hello <b>world</b></p>");
+    expect(email.text).toBeUndefined();
+  });
+
+  it("extracts both html and text from multipart/alternative", async () => {
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: Multipart",
+      'Content-Type: multipart/alternative; boundary="boundary42"',
+      "",
+      "--boundary42",
+      "Content-Type: text/plain; charset=utf-8",
+      "",
+      "Hello world",
+      "",
+      "--boundary42",
+      "Content-Type: text/html; charset=utf-8",
+      "",
+      "<p>Hello world</p>",
+      "",
+      "--boundary42--",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.text?.trim()).toBe("Hello world");
+    expect(email.html?.trim()).toContain("<p>Hello world</p>");
+  });
+});
+
+describe("parseMessage — attachments", () => {
+  it("extracts a binary attachment with size and content", async () => {
+    // Base64 for 5 bytes: "hello"
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: With attachment",
+      'Content-Type: multipart/mixed; boundary="b"',
+      "",
+      "--b",
+      "Content-Type: text/plain",
+      "",
+      "See attached.",
+      "",
+      "--b",
+      "Content-Type: application/octet-stream; name=hello.bin",
+      "Content-Disposition: attachment; filename=hello.bin",
+      "Content-Transfer-Encoding: base64",
+      "",
+      "aGVsbG8=",
+      "",
+      "--b--",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.attachments).toHaveLength(1);
+    const att = email.attachments[0]!;
+
+    expect(att.filename).toBe("hello.bin");
+    expect(att.mimeType).toBe("application/octet-stream");
+    expect(att.disposition).toBe("attachment");
+    expect(att.size).toBe(5);
+    expect(att.content).toBeInstanceOf(ArrayBuffer);
+
+    const bytes = new Uint8Array(att.content!);
+
+    expect(Array.from(bytes)).toEqual([104, 101, 108, 108, 111]);
+  });
+
+  it("leaves filename undefined when no filename parameter is declared", async () => {
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: Nameless",
+      'Content-Type: multipart/mixed; boundary="b"',
+      "",
+      "--b",
+      "Content-Type: text/plain",
+      "",
+      "See attached.",
+      "",
+      "--b",
+      "Content-Type: application/octet-stream",
+      "Content-Disposition: attachment",
+      "Content-Transfer-Encoding: base64",
+      "",
+      "aGVsbG8=",
+      "",
+      "--b--",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.attachments).toHaveLength(1);
+    expect(email.attachments[0]?.filename).toBeUndefined();
+    expect(email.attachments[0]?.mimeType).toBe("application/octet-stream");
+  });
+
+  it("surfaces both a real attachment and an inline cid image in one multipart/mixed", async () => {
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: Combined",
+      'Content-Type: multipart/mixed; boundary="outer"',
+      "",
+      "--outer",
+      'Content-Type: multipart/related; boundary="inner"',
+      "",
+      "--inner",
+      "Content-Type: text/html",
+      "",
+      '<p>hi <img src="cid:logo@example"></p>',
+      "",
+      "--inner",
+      "Content-Type: image/png",
+      "Content-Disposition: inline",
+      "Content-ID: <logo@example>",
+      "Content-Transfer-Encoding: base64",
+      "",
+      "iVBORw0KGgo=",
+      "",
+      "--inner--",
+      "",
+      "--outer",
+      "Content-Type: application/pdf; name=report.pdf",
+      "Content-Disposition: attachment; filename=report.pdf",
+      "Content-Transfer-Encoding: base64",
+      "",
+      "JVBERi0xLjQK",
+      "",
+      "--outer--",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.attachments).toHaveLength(2);
+
+    const inline = email.attachments.find((a) => a.disposition === "inline");
+    const attached = email.attachments.find((a) => a.disposition === "attachment");
+
+    expect(inline?.contentId).toBe("<logo@example>");
+    expect(attached?.filename).toBe("report.pdf");
+    expect(attached?.mimeType).toBe("application/pdf");
+  });
+
+  it("defaults disposition to 'attachment' when the header is absent", async () => {
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: With attachment",
+      'Content-Type: multipart/mixed; boundary="b"',
+      "",
+      "--b",
+      "Content-Type: text/plain",
+      "",
+      "See attached.",
+      "",
+      "--b",
+      "Content-Type: application/octet-stream; name=hello.bin",
+      "Content-Transfer-Encoding: base64",
+      "",
+      "aGVsbG8=",
+      "",
+      "--b--",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.attachments[0]?.disposition).toBe("attachment");
+  });
+
+  it("marks cid-referenced inline images with disposition 'inline' and contentId", async () => {
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: Inline image",
+      'Content-Type: multipart/related; boundary="b"',
+      "",
+      "--b",
+      "Content-Type: text/html",
+      "",
+      '<img src="cid:logo@example">',
+      "",
+      "--b",
+      "Content-Type: image/png",
+      "Content-Disposition: inline",
+      "Content-ID: <logo@example>",
+      "Content-Transfer-Encoding: base64",
+      "",
+      "iVBORw0KGgo=",
+      "",
+      "--b--",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.attachments).toHaveLength(1);
+    const att = email.attachments[0]!;
+
+    expect(att.disposition).toBe("inline");
+    expect(att.contentId).toBe("<logo@example>");
+  });
+});
+
+describe("parseMessage — accepts ArrayBuffer input", () => {
+  it("handles ArrayBuffer as well as string", async () => {
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: Buffer",
+      "",
+      "body",
+      "",
+    ]);
+
+    const buffer = new TextEncoder().encode(raw).buffer as ArrayBuffer;
+
+    const email = await parseMessage(buffer);
+
+    expect(email.subject).toBe("Buffer");
+  });
+});
+
+describe("parseMessage — missing Message-ID", () => {
+  it("returns undefined messageId when the header is absent", async () => {
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: Anonymous",
+      "",
+      "body",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.messageId).toBeUndefined();
+  });
+});
+
+describe("extractThreadingHeaders", () => {
+  it("pulls the three threading fields out of a ParsedEmail", async () => {
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: Re: Hi",
+      "Message-ID: <abc@example.com>",
+      "In-Reply-To: <parent@example.com>",
+      "References: <root@example.com> <parent@example.com>",
+      "",
+      "body",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+    const headers = extractThreadingHeaders(email);
+
+    expect(headers).toEqual({
+      messageId: "<abc@example.com>",
+      inReplyTo: "<parent@example.com>",
+      references: ["<root@example.com>", "<parent@example.com>"],
+    });
+  });
+
+  it("returns empty references when none are present", async () => {
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: New thread",
+      "Message-ID: <new@example.com>",
+      "",
+      "body",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+    const headers = extractThreadingHeaders(email);
+
+    expect(headers.references).toEqual([]);
+    expect(headers.messageId).toBe("<new@example.com>");
+    expect(headers.inReplyTo).toBeUndefined();
+  });
+
+  it("round-trips References tokens through the raw header value", async () => {
+    const tokens = [
+      "<a@example.com>",
+      "<b@example.com>",
+      "<c@example.com>",
+    ];
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: Re: round",
+      `References: ${tokens.join(" ")}`,
+      "",
+      "body",
+      "",
+    ]);
+
+    const email = await parseMessage(raw);
+
+    expect(email.references.join(" ")).toBe(tokens.join(" "));
+  });
+});

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -1,0 +1,248 @@
+/**
+ * MIME parsing: an async entry point ({@link parseMessage}) that turns
+ * raw email bytes into a structured {@link ParsedEmail}, plus a sync
+ * helper ({@link extractThreadingHeaders}) that pulls a narrow subset
+ * out of the result.
+ *
+ * `parseMessage` is the only async function in the library; every other
+ * export works on the `ParsedEmail` shape it produces.
+ *
+ * @module
+ */
+
+import PostalMime from "postal-mime";
+import type {
+  Address as PMAddress,
+  Attachment as PMAttachment,
+  Email as PMEmail,
+  Header as PMHeader,
+  Mailbox as PMMailbox,
+} from "postal-mime";
+
+import type {
+  Attachment,
+  EmailAddress,
+  ParsedEmail,
+  ThreadingHeaders,
+} from "./types.ts";
+
+function mapMailbox(mailbox: PMMailbox): EmailAddress {
+  const trimmed = mailbox.name?.trim();
+
+  if (!trimmed) {
+    return { address: mailbox.address };
+  }
+
+  return { name: trimmed, address: mailbox.address };
+}
+
+function flattenAddresses(list: PMAddress[] | undefined): EmailAddress[] {
+  if (!list || list.length === 0) {
+    return [];
+  }
+
+  const out: EmailAddress[] = [];
+
+  for (const entry of list) {
+    if (entry.group) {
+      for (const m of entry.group) {
+        out.push(mapMailbox(m));
+      }
+
+      continue;
+    }
+
+    out.push(mapMailbox(entry));
+  }
+
+  return out;
+}
+
+function firstAddress(
+  entry: PMAddress | PMAddress[] | undefined,
+): EmailAddress | undefined {
+  if (!entry) {
+    return undefined;
+  }
+
+  if (Array.isArray(entry)) {
+    return firstAddress(entry[0]);
+  }
+
+  if (entry.group) {
+    const first = entry.group[0];
+
+    return first ? mapMailbox(first) : undefined;
+  }
+
+  return mapMailbox(entry);
+}
+
+function parseReferencesHeader(raw: string | undefined): string[] {
+  if (!raw) {
+    return [];
+  }
+
+  return raw.split(/\s+/).filter((token) => token.length > 0);
+}
+
+function parseDate(raw: string | undefined): Date | undefined {
+  if (!raw) {
+    return undefined;
+  }
+
+  const d = new Date(raw);
+
+  if (Number.isNaN(d.getTime())) {
+    return undefined;
+  }
+
+  return d;
+}
+
+function toArrayBuffer(
+  content: ArrayBuffer | Uint8Array | string | undefined,
+): ArrayBuffer | undefined {
+  if (content === undefined) {
+    return undefined;
+  }
+
+  if (typeof content === "string") {
+    // Defensive: parseMessage forces `attachmentEncoding: "arraybuffer"`,
+    // so postal-mime should never deliver a string. If it did we would
+    // be about to encode base64-as-bytes and corrupt the attachment
+    // silently, so fail loudly instead.
+    throw new Error(
+      "parseMessage: postal-mime returned string attachment content; expected ArrayBuffer.",
+    );
+  }
+
+  if (content instanceof Uint8Array) {
+    // Copy the view into a dedicated ArrayBuffer. The original .buffer is
+    // typed as ArrayBuffer | SharedArrayBuffer; we always return ArrayBuffer.
+    const copy = new ArrayBuffer(content.byteLength);
+
+    new Uint8Array(copy).set(content);
+
+    return copy;
+  }
+
+  return content;
+}
+
+function mapAttachment(att: PMAttachment): Attachment {
+  const content = toArrayBuffer(att.content);
+  const size = content?.byteLength ?? 0;
+  const disposition: "attachment" | "inline" =
+    att.disposition === "inline" ? "inline" : "attachment";
+
+  return {
+    filename: att.filename ?? undefined,
+    mimeType: att.mimeType,
+    disposition,
+    contentId: att.contentId,
+    size,
+    content,
+  };
+}
+
+function buildHeaders(list: PMHeader[] | undefined): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+
+  if (!list) {
+    return map;
+  }
+
+  for (const h of list) {
+    // postal-mime already lowercases header.key.
+    const existing = map.get(h.key);
+
+    if (existing) {
+      existing.push(h.value);
+
+      continue;
+    }
+
+    map.set(h.key, [h.value]);
+  }
+
+  return map;
+}
+
+function toParsedEmail(p: PMEmail): ParsedEmail {
+  return {
+    messageId: p.messageId,
+    inReplyTo: p.inReplyTo,
+    references: parseReferencesHeader(p.references),
+    subject: p.subject,
+    from: firstAddress(p.from),
+    to: flattenAddresses(p.to),
+    cc: flattenAddresses(p.cc),
+    bcc: flattenAddresses(p.bcc),
+    replyTo: firstAddress(p.replyTo),
+    date: parseDate(p.date),
+    html: p.html,
+    text: p.text,
+    attachments: (p.attachments ?? []).map(mapAttachment),
+    headers: buildHeaders(p.headers),
+  };
+}
+
+/**
+ * Parse raw MIME bytes into a structured {@link ParsedEmail}.
+ *
+ * Accepts the email as a string (raw RFC 5322 source) or an
+ * `ArrayBuffer` (common when reading from storage or a transport layer).
+ * Per-field malformations degrade gracefully: missing fields become
+ * `undefined`, empty collections become `[]`, and an unparseable `Date:`
+ * header yields `undefined`.
+ *
+ * @param raw The email source.
+ * @returns A structured {@link ParsedEmail}.
+ * @throws {Error} When `raw` is not recognizable MIME and `postal-mime`
+ * cannot produce a parse tree (corrupt envelope, truncated multipart,
+ * etc.). Per-field issues do **not** throw.
+ *
+ * @example
+ * ```ts
+ * import { parseMessage } from "@oflabs/mail-utils";
+ *
+ * declare const rawEml: string;
+ * const email = await parseMessage(rawEml);
+ * const { to, from, subject } = email;
+ * ```
+ */
+export async function parseMessage(
+  raw: string | ArrayBuffer,
+): Promise<ParsedEmail> {
+  const parsed = await PostalMime.parse(raw, {
+    attachmentEncoding: "arraybuffer",
+  });
+
+  return toParsedEmail(parsed);
+}
+
+/**
+ * Pull the three threading-relevant fields out of a {@link ParsedEmail}.
+ *
+ * Useful during live ingestion when you only need to determine thread
+ * membership and want to avoid holding a reference to the full record.
+ *
+ * @param email A parsed email.
+ * @returns The `messageId`, `inReplyTo`, and `references` fields.
+ *
+ * @example
+ * ```ts
+ * const headers = extractThreadingHeaders(email);
+ * // { messageId: "<abc@x>", inReplyTo: "<parent@x>", references: ["<root@x>", "<parent@x>"] }
+ * ```
+ */
+export function extractThreadingHeaders(
+  email: ParsedEmail,
+): ThreadingHeaders {
+  return {
+    messageId: email.messageId,
+    inReplyTo: email.inReplyTo,
+    references: email.references,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 /**
  * Core types shared across the addressing, parsing, threading, and
- * composition modules. Currently exports {@link EmailAddress}.
+ * composition modules. All fields are `readonly` at both the slot and
+ * collection level — these records are values, never mutated in place.
  *
  * @module
  */
@@ -8,12 +9,104 @@
 /**
  * A single email mailbox.
  *
- * `address` is the `local@domain` part; `name` is the optional display name.
- * Fields are `readonly` — this type is treated as a value, never mutated in
- * place. Use {@link parseAddress} or {@link parseAddressList} to obtain
- * instances from a header string; use {@link formatAddress} to serialize.
+ * `address` is the `local@domain` part; `name` is the optional display
+ * name. When present, `name` is a non-empty, trimmed string. Use
+ * {@link parseAddress} / {@link parseAddressList} to obtain instances
+ * from header strings; {@link formatAddress} to serialize.
  */
 export type EmailAddress = {
+  /** RFC 5322 display name. When present, guaranteed non-empty and trimmed. */
   readonly name?: string;
+  /** `local@domain` part of the mailbox. */
   readonly address: string;
+};
+
+/**
+ * A MIME part extracted from a parsed email — either an attachment or an
+ * inline cid-referenced body part.
+ *
+ * `content` is present after parsing and may be stripped by callers that
+ * persist the payload elsewhere while retaining the metadata. The only
+ * function in this library that requires `content` to be present is the
+ * forthcoming `createForward`; everything else tolerates `content`
+ * being `undefined`.
+ *
+ * Use {@link isInlineAttachment} to distinguish inline cid-referenced
+ * images from user-facing attachments.
+ */
+export type Attachment = {
+  /** Filename as declared in `Content-Disposition` / `Content-Type name=`. */
+  readonly filename?: string | undefined;
+  /** MIME type, e.g. `image/png`. */
+  readonly mimeType: string;
+  /** `Content-Disposition` value. Defaults to `"attachment"` when the header is absent. */
+  readonly disposition: "attachment" | "inline";
+  /** `Content-ID` including angle brackets, e.g. `<logo@example>`. Usually present for inline parts. */
+  readonly contentId?: string | undefined;
+  /**
+   * Byte length of the decoded content at parse time. Remains set to
+   * the original length even if `content` is later stripped.
+   */
+  readonly size: number;
+  /**
+   * Decoded binary payload. Present after {@link parseMessage}; may be
+   * `undefined` once callers have persisted the payload to storage.
+   */
+  readonly content?: ArrayBuffer | undefined;
+};
+
+/**
+ * A parsed email in structured form. Produced by {@link parseMessage}.
+ *
+ * Empty collections are always represented as empty arrays (never
+ * `undefined`). `date` is a `Date` when the `Date:` header is
+ * parseable, otherwise `undefined`. `headers` preserves every
+ * occurrence of each header in order — duplicate `Received:` /
+ * `DKIM-Signature:` lines each keep their own entry.
+ */
+export type ParsedEmail = {
+  /** RFC 5322 `Message-ID:` including angle brackets, e.g. `<abc@example.com>`. */
+  readonly messageId?: string | undefined;
+  /** Single Message-ID referenced in `In-Reply-To:`, including angle brackets. */
+  readonly inReplyTo?: string | undefined;
+  /** Chronologically ordered Message-IDs from `References:`. Empty when absent. */
+  readonly references: readonly string[];
+  /** `Subject:` with RFC 2047 encoded-words already decoded. */
+  readonly subject?: string | undefined;
+  /** First mailbox from `From:`. Group syntax yields the first member. */
+  readonly from?: EmailAddress | undefined;
+  /** Flattened mailboxes from `To:`. Groups are expanded. */
+  readonly to: readonly EmailAddress[];
+  /** Flattened mailboxes from `Cc:`. */
+  readonly cc: readonly EmailAddress[];
+  /** Flattened mailboxes from `Bcc:`. */
+  readonly bcc: readonly EmailAddress[];
+  /** First mailbox from `Reply-To:`. Full list remains in {@link ParsedEmail.headers}. */
+  readonly replyTo?: EmailAddress | undefined;
+  /** Parsed `Date:`. `undefined` when the header is absent or unparseable. */
+  readonly date?: Date | undefined;
+  /** Decoded `text/html` body, when present. */
+  readonly html?: string | undefined;
+  /** Decoded `text/plain` body, when present. */
+  readonly text?: string | undefined;
+  /** Both attachments and inline cid-referenced parts, in source order. */
+  readonly attachments: readonly Attachment[];
+  /**
+   * Every header occurrence. Keys are lowercased (`headers.get("Received")`
+   * returns `undefined`; use `headers.get("received")`). Values are the
+   * raw header values — not RFC 2047 decoded — so they remain suitable
+   * for DKIM verification.
+   */
+  readonly headers: ReadonlyMap<string, readonly string[]>;
+};
+
+/**
+ * The subset of {@link ParsedEmail} fields needed to determine thread
+ * membership. Extract via {@link extractThreadingHeaders} when you only
+ * need to make threading decisions without holding the full record.
+ */
+export type ThreadingHeaders = {
+  readonly messageId?: string | undefined;
+  readonly inReplyTo?: string | undefined;
+  readonly references: readonly string[];
 };


### PR DESCRIPTION
Adds the second module of the library. `parseMessage` turns raw MIME bytes into a structured `ParsedEmail` — it's the only async function in the library. Every other module (threading, composition) will consume this shape.

The parser is tolerant of messy real-world mail: missing fields come back as `undefined`, empty collections as `[]`, unparseable dates as `undefined`. It only throws when postal-mime can't make sense of the MIME envelope at all (corrupt boundaries, truncated multipart).

Duplicate headers are preserved in full — a 12-hop `Received:` chain survives intact, multiple `DKIM-Signature:` lines are kept in order, all with lowercased keys. Types expose this as `ReadonlyMap<string, readonly string[]>` so consumers can't accidentally mutate a shared record.

Also adds `extractThreadingHeaders` — the sync helper for pulling `messageId` / `inReplyTo` / `references` out without holding the full record.

78 tests pass (28 new). JSR dry-run clean. No slow types.

Closes #1