### PR TITLE
Implement content module

### DIFF
--- a/src/content.test.ts
+++ b/src/content.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  extractBody,
+  isInlineAttachment,
+  listAttachments,
+} from "./content.ts";
+import type { Attachment, ParsedEmail } from "./types.ts";
+
+function makeEmail(overrides: Partial<ParsedEmail> = {}): ParsedEmail {
+  return {
+    references: [],
+    to: [],
+    cc: [],
+    bcc: [],
+    attachments: [],
+    headers: new Map(),
+    ...overrides,
+  };
+}
+
+function makeAttachment(overrides: Partial<Attachment> = {}): Attachment {
+  return {
+    mimeType: "application/octet-stream",
+    disposition: "attachment",
+    size: 0,
+    ...overrides,
+  };
+}
+
+describe("extractBody", () => {
+  it("returns html when only html is present", () => {
+    const body = extractBody(makeEmail({ html: "<p>hi</p>" }));
+
+    expect(body).toEqual({ html: "<p>hi</p>" });
+  });
+
+  it("returns text when only text is present", () => {
+    const body = extractBody(makeEmail({ text: "hello" }));
+
+    expect(body).toEqual({ text: "hello" });
+  });
+
+  it("returns both when both are present", () => {
+    const body = extractBody(
+      makeEmail({ html: "<p>hi</p>", text: "hello" }),
+    );
+
+    expect(body).toEqual({ html: "<p>hi</p>", text: "hello" });
+  });
+
+  it("returns an empty object when neither is present", () => {
+    expect(extractBody(makeEmail())).toEqual({});
+  });
+
+  it("does not sanitize HTML", () => {
+    // Contract: content module never sanitizes. Caller is responsible.
+    const body = extractBody(
+      makeEmail({ html: '<img src=x onerror="alert(1)">' }),
+    );
+
+    expect(body.html).toBe('<img src=x onerror="alert(1)">');
+  });
+});
+
+describe("isInlineAttachment", () => {
+  it("returns true for inline parts with a contentId", () => {
+    expect(
+      isInlineAttachment(
+        makeAttachment({
+          disposition: "inline",
+          contentId: "<logo@example>",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for inline parts missing a contentId", () => {
+    expect(
+      isInlineAttachment(makeAttachment({ disposition: "inline" })),
+    ).toBe(false);
+  });
+
+  it("returns false for inline parts with an empty contentId", () => {
+    expect(
+      isInlineAttachment(
+        makeAttachment({ disposition: "inline", contentId: "" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for attachments even when a contentId is set", () => {
+    expect(
+      isInlineAttachment(
+        makeAttachment({
+          disposition: "attachment",
+          contentId: "<logo@example>",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for regular attachments", () => {
+    expect(isInlineAttachment(makeAttachment())).toBe(false);
+  });
+});
+
+describe("listAttachments", () => {
+  it("filters out inline parts with a contentId", () => {
+    const inline = makeAttachment({
+      disposition: "inline",
+      contentId: "<logo@example>",
+      filename: "logo.png",
+    });
+    const attached = makeAttachment({
+      filename: "report.pdf",
+      mimeType: "application/pdf",
+    });
+
+    const result = listAttachments(
+      makeEmail({ attachments: [inline, attached] }),
+    );
+
+    expect(result).toEqual([attached]);
+  });
+
+  it("keeps inline parts that lack a contentId (treated as user-facing)", () => {
+    const orphanInline = makeAttachment({
+      disposition: "inline",
+      filename: "oops.png",
+    });
+
+    const result = listAttachments(
+      makeEmail({ attachments: [orphanInline] }),
+    );
+
+    expect(result).toEqual([orphanInline]);
+  });
+
+  it("preserves original order", () => {
+    const a = makeAttachment({ filename: "a.txt" });
+    const cid = makeAttachment({
+      disposition: "inline",
+      contentId: "<cid@x>",
+    });
+    const b = makeAttachment({ filename: "b.txt" });
+
+    const result = listAttachments(
+      makeEmail({ attachments: [a, cid, b] }),
+    );
+
+    expect(result).toEqual([a, b]);
+  });
+
+  it("returns [] when there are no attachments", () => {
+    expect(listAttachments(makeEmail())).toEqual([]);
+  });
+
+  it("returns [] when every attachment is inline with a contentId", () => {
+    const attachments: Attachment[] = [
+      makeAttachment({ disposition: "inline", contentId: "<1@x>" }),
+      makeAttachment({ disposition: "inline", contentId: "<2@x>" }),
+    ];
+
+    expect(listAttachments(makeEmail({ attachments }))).toEqual([]);
+  });
+});

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,0 +1,97 @@
+/**
+ * Inspectors for the body and attachments of a {@link ParsedEmail}.
+ *
+ * Pure, sync predicates and extractors — no sanitization, no DOM. The
+ * caller owns rendering decisions.
+ *
+ * @example
+ * ```ts
+ * import {
+ *   extractBody,
+ *   listAttachments,
+ *   isInlineAttachment,
+ * } from "@oflabs/mail-utils";
+ *
+ * const body = extractBody(email);        // { html?, text? }
+ * const files = listAttachments(email);   // user-facing attachments only
+ * ```
+ *
+ * @module
+ */
+
+import type { Attachment, ParsedEmail } from "./types.ts";
+
+/**
+ * Extract whichever of the HTML and plain-text bodies are present.
+ *
+ * Returns the fields as-is, without sanitization. HTML should be run
+ * through a DOM-aware sanitizer (e.g. DOMPurify) in the rendering
+ * layer before being inserted into a document.
+ *
+ * @param email The parsed email to read from.
+ * @returns An object containing whichever of `html` / `text` the email
+ * carries. Both keys are omitted when absent.
+ *
+ * @example
+ * ```ts
+ * const body = extractBody(email);
+ * if (body.html) renderHtml(body.html);
+ * else if (body.text) renderPlain(body.text);
+ * ```
+ */
+export function extractBody(
+  email: ParsedEmail,
+): { html?: string | undefined; text?: string | undefined } {
+  const out: { html?: string; text?: string } = {};
+
+  if (email.html !== undefined) {
+    out.html = email.html;
+  }
+
+  if (email.text !== undefined) {
+    out.text = email.text;
+  }
+
+  return out;
+}
+
+/**
+ * Return `true` iff the attachment is an inline part referenced from
+ * the HTML body via a `cid:` URL rather than a user-facing attachment.
+ *
+ * An inline part has `disposition === "inline"` and carries a
+ * non-empty `contentId`. Inline parts missing or with an empty
+ * `contentId` (malformed clients) are treated as regular attachments
+ * since they cannot be `cid:`-referenced from the HTML body.
+ *
+ * @example
+ * ```ts
+ * isInlineAttachment({ disposition: "inline", contentId: "<logo@x>", ... }) // true
+ * isInlineAttachment({ disposition: "inline", ... })                         // false
+ * isInlineAttachment({ disposition: "attachment", ... })                     // false
+ * ```
+ */
+export function isInlineAttachment(attachment: Attachment): boolean {
+  return (
+    attachment.disposition === "inline" &&
+    attachment.contentId !== undefined &&
+    attachment.contentId.length > 0
+  );
+}
+
+/**
+ * Return the user-facing attachments — attachments and inline parts
+ * that are **not** referenced from the HTML body via `cid:`.
+ *
+ * Equivalent to filtering out every entry for which
+ * {@link isInlineAttachment} returns `true`.
+ *
+ * @example
+ * ```ts
+ * const files = listAttachments(email);
+ * for (const f of files) console.log(f.filename, f.size);
+ * ```
+ */
+export function listAttachments(email: ParsedEmail): Attachment[] {
+  return email.attachments.filter((a) => !isInlineAttachment(a));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,3 +35,9 @@ export {
 } from "./addressing.ts";
 
 export { extractThreadingHeaders, parseMessage } from "./parsing.ts";
+
+export {
+  extractBody,
+  isInlineAttachment,
+  listAttachments,
+} from "./content.ts";


### PR DESCRIPTION
Three small, pure functions for inspecting an email's body and attachments.

- `extractBody` returns `{ html?, text? }` exactly as parsed — no sanitization. HTML rendering is up to the caller and its DOM-aware sanitizer.
- `isInlineAttachment` correctly identifies cid-referenced inline parts, and treats inline parts without a real `contentId` as regular attachments (they can't be cid-referenced anyway).
- `listAttachments` returns the user-facing set — what you'd show in an "Attachments" UI, with inline logos stripped.

15 new tests, all 93 green, JSR dry-run clean.

Closes #5