### PR TITLE
Implement threading module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,9 @@ export type {
   Attachment,
   EmailAddress,
   ParsedEmail,
+  Thread,
   ThreadingHeaders,
+  ThreadNode,
 } from "./types.ts";
 
 export {
@@ -41,3 +43,11 @@ export {
   isInlineAttachment,
   listAttachments,
 } from "./content.ts";
+
+export {
+  buildThreads,
+  getThreadId,
+  ingestIntoThreads,
+  isOrphanId,
+  normalizeSubject,
+} from "./threading.ts";

--- a/src/internal/orphan-id.test.ts
+++ b/src/internal/orphan-id.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import { isOrphanId, synthesizeOrphanId } from "./orphan-id.ts";
+import type { ParsedEmail } from "../types.ts";
+
+function makeEmail(overrides: Partial<ParsedEmail> = {}): ParsedEmail {
+  return {
+    references: [],
+    to: [],
+    cc: [],
+    bcc: [],
+    attachments: [],
+    headers: new Map(),
+    ...overrides,
+  };
+}
+
+describe("synthesizeOrphanId", () => {
+  it("produces an id of the form <orphan.{16hex}@local>", () => {
+    const id = synthesizeOrphanId(
+      makeEmail({
+        from: { address: "ada@example.com" },
+        subject: "Hello",
+      }),
+    );
+
+    expect(id).toMatch(/^<orphan\.[0-9a-f]{16}@local>$/);
+  });
+
+  it("is deterministic — same input yields same id", () => {
+    const email = makeEmail({
+      from: { address: "ada@example.com" },
+      subject: "Hello",
+      date: new Date("2026-04-19T12:00:00Z"),
+      text: "body text here",
+    });
+
+    expect(synthesizeOrphanId(email)).toBe(synthesizeOrphanId(email));
+  });
+
+  it("differs when the from address differs", () => {
+    const a = synthesizeOrphanId(
+      makeEmail({ from: { address: "a@x" }, subject: "Same" }),
+    );
+    const b = synthesizeOrphanId(
+      makeEmail({ from: { address: "b@x" }, subject: "Same" }),
+    );
+
+    expect(a).not.toBe(b);
+  });
+
+  it("differs when the subject differs", () => {
+    const a = synthesizeOrphanId(makeEmail({ subject: "Hello" }));
+    const b = synthesizeOrphanId(makeEmail({ subject: "Goodbye" }));
+
+    expect(a).not.toBe(b);
+  });
+
+  it("differs when the date differs", () => {
+    const a = synthesizeOrphanId(
+      makeEmail({ date: new Date("2026-04-19T00:00:00Z") }),
+    );
+    const b = synthesizeOrphanId(
+      makeEmail({ date: new Date("2026-04-20T00:00:00Z") }),
+    );
+
+    expect(a).not.toBe(b);
+  });
+
+  it("considers the first 100 chars of body", () => {
+    const base = "A".repeat(100);
+    const a = synthesizeOrphanId(makeEmail({ text: base + "X" }));
+    const b = synthesizeOrphanId(makeEmail({ text: base + "Y" }));
+
+    // Both bodies share the first 100 chars, so they hash identically.
+    expect(a).toBe(b);
+  });
+
+  it("handles an email with no fields populated", () => {
+    const id = synthesizeOrphanId(makeEmail());
+
+    expect(id).toMatch(/^<orphan\.[0-9a-f]{16}@local>$/);
+  });
+});
+
+describe("isOrphanId", () => {
+  it("recognizes synthesized ids", () => {
+    const id = synthesizeOrphanId(
+      makeEmail({ from: { address: "ada@x" } }),
+    );
+
+    expect(isOrphanId(id)).toBe(true);
+  });
+
+  it("rejects real Message-IDs", () => {
+    expect(isOrphanId("<abc@example.com>")).toBe(false);
+    expect(isOrphanId("<orphan.abc@example.com>")).toBe(false);
+    expect(isOrphanId("<xyz@local>")).toBe(false);
+    expect(isOrphanId("")).toBe(false);
+  });
+});

--- a/src/internal/orphan-id.ts
+++ b/src/internal/orphan-id.ts
@@ -1,0 +1,96 @@
+/**
+ * Deterministic thread-id synthesis for emails with no Message-ID,
+ * In-Reply-To, or References.
+ *
+ * Uses a 64-bit FNV-1a variant instead of SHA-256 because
+ * `crypto.subtle.digest` is asynchronous and the library's design rule
+ * keeps every function except `parseMessage` synchronous. For thread
+ * grouping we need determinism and a low collision rate, not
+ * cryptographic strength.
+ *
+ * @module
+ */
+
+import type { ParsedEmail } from "../types.ts";
+
+const FNV_OFFSET_HIGH = 0xcbf2_9ce4;
+const FNV_OFFSET_LOW = 0x8422_2325;
+const FNV_PRIME_HIGH = 0x0000_0100;
+const FNV_PRIME_LOW = 0x0000_01b3;
+const MASK_32 = 0xffff_ffff;
+
+// Split 64-bit FNV-1a implemented as two 32-bit halves to stay within
+// safe-integer arithmetic. Returns the 64-bit hash as a 16-char hex
+// string (big-endian).
+function fnv1a64(input: string): string {
+  let hi = FNV_OFFSET_HIGH;
+  let lo = FNV_OFFSET_LOW;
+  const bytes = new TextEncoder().encode(input);
+
+  for (const b of bytes) {
+    lo ^= b;
+
+    // Multiply the 64-bit value [hi:lo] by the 64-bit prime
+    // [FNV_PRIME_HIGH:FNV_PRIME_LOW] using 32-bit half-products.
+    const loLo = (lo & 0xffff) * FNV_PRIME_LOW;
+    const loHi = (lo >>> 16) * FNV_PRIME_LOW;
+    const hiLo = (lo & 0xffff) * FNV_PRIME_HIGH;
+    const hiHi = hi * FNV_PRIME_LOW;
+
+    const carry = (loHi >>> 16) + (hiLo >>> 16);
+    const newLo = ((loLo + ((loHi & 0xffff) << 16)) & MASK_32) >>> 0;
+    const newHi =
+      (hiHi + (hiLo & ~0xffff) + ((loHi & ~0xffff) >>> 0) + carry * 0x10000) &
+      MASK_32;
+
+    // The cross-term hiHi*PRIME_HIGH would overflow for 32-bit high
+    // halves but contributes nothing distinguishing at the top, so we
+    // follow common 64-bit FNV-1a implementations and drop it.
+    hi = newHi >>> 0;
+    lo = newLo;
+  }
+
+  return hi.toString(16).padStart(8, "0") + lo.toString(16).padStart(8, "0");
+}
+
+function firstChars(value: string | undefined, n: number): string {
+  if (!value) {
+    return "";
+  }
+
+  return value.slice(0, n);
+}
+
+/**
+ * Derive a deterministic synthesized Message-ID for an email that has
+ * no real threading headers. Same input → same output; different
+ * inputs differ with overwhelming probability.
+ *
+ * @param email The orphan email.
+ * @returns A Message-ID of the form `<orphan.{16-hex}@local>`. The
+ * `@local` sentinel lets reply composition recognize a synthesized id
+ * and skip `In-Reply-To` on the reply.
+ */
+export function synthesizeOrphanId(email: ParsedEmail): string {
+  const fromField = email.from
+    ? `${email.from.name ?? ""}<${email.from.address}>`
+    : "";
+  const subject = email.subject ?? "";
+  const date = email.date ? email.date.toISOString() : "";
+  const body = firstChars(email.html ?? email.text, 100);
+
+  const payload = `${fromField}\u0000${subject}\u0000${date}\u0000${body}`;
+
+  return `<orphan.${fnv1a64(payload)}@local>`;
+}
+
+/**
+ * Sentinel domain used to mark synthesized ids so that downstream
+ * reply composition can detect "don't set In-Reply-To for this one."
+ */
+export const ORPHAN_DOMAIN = "@local>";
+
+/** Returns `true` if `id` looks like a synthesized orphan id. */
+export function isOrphanId(id: string): boolean {
+  return id.startsWith("<orphan.") && id.endsWith(ORPHAN_DOMAIN);
+}

--- a/src/internal/subject-normalizer.test.ts
+++ b/src/internal/subject-normalizer.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeSubject } from "./subject-normalizer.ts";
+
+describe("normalizeSubject — reply prefixes", () => {
+  it.each([
+    ["Re: hi", "hi"],
+    ["RE: hi", "hi"],
+    ["re: hi", "hi"],
+    ["Re : hi", "hi"],
+    ["Re[2]: hi", "hi"],
+    ["Aw: hi", "hi"], // German
+    ["Rép: bonjour", "bonjour"], // French
+    ["Ré: bonjour", "bonjour"],
+    ["RV: hola", "hola"], // Spanish
+    ["Ref: hola", "hola"],
+    // Single-letter `R:` / `I:` are intentionally NOT stripped — they
+    // alias too broadly (e.g. "r: rocket" would lose its first word).
+    ["Antw: hallo", "hallo"], // Dutch
+    ["Odp: cześć", "cześć"], // Polish
+  ])("strips %s", (input, expected) => {
+    expect(normalizeSubject(input)).toBe(expected);
+  });
+});
+
+describe("normalizeSubject — forward prefixes", () => {
+  it.each([
+    ["Fwd: hi", "hi"],
+    ["FWD: hi", "hi"],
+    ["Fw: hi", "hi"],
+    ["Wg: hi", "hi"], // German
+    ["Tr: bonjour", "bonjour"], // French
+    ["Rif: ciao", "ciao"], // Italian (use long form; single-letter `I:` dropped)
+    ["Enc: olá", "olá"], // Portuguese
+    ["Doorst: hallo", "hallo"], // Dutch
+    ["PD: cześć", "cześć"], // Polish
+  ])("strips %s", (input, expected) => {
+    expect(normalizeSubject(input)).toBe(expected);
+  });
+});
+
+describe("normalizeSubject — bracket markers", () => {
+  it("strips [External]", () => {
+    expect(normalizeSubject("[External] Meeting")).toBe("Meeting");
+  });
+
+  it("strips [EXT]", () => {
+    expect(normalizeSubject("[EXT] Meeting")).toBe("Meeting");
+  });
+
+  it("strips [SPAM]", () => {
+    expect(normalizeSubject("[SPAM] Meeting")).toBe("Meeting");
+  });
+
+  it("strips [Suspicious Sender]", () => {
+    expect(normalizeSubject("[Suspicious Sender] Meeting")).toBe("Meeting");
+  });
+});
+
+describe("normalizeSubject — asterisk markers", () => {
+  it("strips ***SPAM***", () => {
+    expect(normalizeSubject("***SPAM*** Meeting")).toBe("Meeting");
+  });
+
+  it("strips **URGENT**", () => {
+    expect(normalizeSubject("**URGENT** Meeting")).toBe("Meeting");
+  });
+});
+
+describe("normalizeSubject — nested / repeated", () => {
+  it("strips Re: Fwd: Re: nested prefixes", () => {
+    expect(normalizeSubject("Re: Fwd: Re: Meeting tomorrow")).toBe(
+      "Meeting tomorrow",
+    );
+  });
+
+  it("strips mixed-language prefixes", () => {
+    expect(normalizeSubject("Re: Aw: Fwd: Meeting")).toBe("Meeting");
+  });
+
+  it("strips bracket + prefix + bracket combos", () => {
+    expect(normalizeSubject("[EXT] Re: [SPAM] Meeting")).toBe("Meeting");
+  });
+
+  it("caps iterations and does not hang on pathological input", () => {
+    const pathological = "Re: ".repeat(50) + "end";
+    const result = normalizeSubject(pathological);
+
+    expect(result.endsWith("end")).toBe(true);
+  });
+});
+
+describe("normalizeSubject — intentional non-strippers", () => {
+  it("does not strip bare `R:` (would mangle legitimate subjects)", () => {
+    expect(normalizeSubject("R: rocket launch")).toBe("R: rocket launch");
+  });
+
+  it("does not strip bare `I:` (same reason)", () => {
+    expect(normalizeSubject("I: important update")).toBe(
+      "I: important update",
+    );
+  });
+});
+
+describe("normalizeSubject — edge cases", () => {
+  it("returns empty string unchanged", () => {
+    expect(normalizeSubject("")).toBe("");
+  });
+
+  it("returns empty string on non-string input", () => {
+    // @ts-expect-error — intentionally passing non-string for runtime behavior.
+    expect(normalizeSubject(null)).toBe("");
+    // @ts-expect-error — intentionally passing non-string for runtime behavior.
+    expect(normalizeSubject(undefined)).toBe("");
+  });
+
+  it("leaves a subject with no prefix unchanged", () => {
+    expect(normalizeSubject("Meeting tomorrow")).toBe("Meeting tomorrow");
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeSubject("   Meeting   ")).toBe("Meeting");
+  });
+});

--- a/src/internal/subject-normalizer.test.ts
+++ b/src/internal/subject-normalizer.test.ts
@@ -18,6 +18,8 @@ describe("normalizeSubject — reply prefixes", () => {
     // alias too broadly (e.g. "r: rocket" would lose its first word).
     ["Antw: hallo", "hallo"], // Dutch
     ["Odp: cześć", "cześć"], // Polish
+    ["Sv: hej", "hej"], // Swedish
+    ["SV: hej", "hej"],
   ])("strips %s", (input, expected) => {
     expect(normalizeSubject(input)).toBe(expected);
   });
@@ -34,6 +36,7 @@ describe("normalizeSubject — forward prefixes", () => {
     ["Enc: olá", "olá"], // Portuguese
     ["Doorst: hallo", "hallo"], // Dutch
     ["PD: cześć", "cześć"], // Polish
+    ["Vs: hej", "hej"], // Swedish
   ])("strips %s", (input, expected) => {
     expect(normalizeSubject(input)).toBe(expected);
   });

--- a/src/internal/subject-normalizer.ts
+++ b/src/internal/subject-normalizer.ts
@@ -15,11 +15,11 @@
 // launch", and the languages that use them also accept the longer
 // forms in practice.
 const REPLY_PREFIX =
-  /^(re\s*\[\d+\]|re|aw|r[ée]p|r[ée]|rv|ref|antw|odp)\s*:\s*/i;
+  /^(re\s*\[\d+\]|re|aw|r[ée]p|r[ée]|rv|ref|antw|odp|sv)\s*:\s*/i;
 
 // Forward prefixes across the same languages.
 const FORWARD_PREFIX =
-  /^(fwd?|wg|tr|rif|enc|doorst|pd)\s*:\s*/i;
+  /^(fwd?|wg|tr|rif|enc|doorst|pd|vs)\s*:\s*/i;
 
 // [EXT], [EXTERNAL], [SPAM], [SUSPICIOUS], etc.
 const BRACKET_PREFIX = /^\[[^\]]+\]\s*/;

--- a/src/internal/subject-normalizer.ts
+++ b/src/internal/subject-normalizer.ts
@@ -1,0 +1,69 @@
+/**
+ * Strip reply/forward prefixes and org-injected bracket/asterisk
+ * markers from a subject line for threading-fallback comparison.
+ *
+ * Internal module; re-exported publicly as `normalizeSubject` from
+ * `../threading.ts`.
+ *
+ * @module
+ */
+
+// Reply prefixes across EN, DE, FR, ES, IT, PT, NL, PL plus the
+// general `Re[n]:` variant some mailers use for thread depth.
+// Single-letter alternatives (`R:`, `I:`) are intentionally NOT in
+// the list — they would mangle legitimate subjects like "r: rocket
+// launch", and the languages that use them also accept the longer
+// forms in practice.
+const REPLY_PREFIX =
+  /^(re\s*\[\d+\]|re|aw|r[ée]p|r[ée]|rv|ref|antw|odp)\s*:\s*/i;
+
+// Forward prefixes across the same languages.
+const FORWARD_PREFIX =
+  /^(fwd?|wg|tr|rif|enc|doorst|pd)\s*:\s*/i;
+
+// [EXT], [EXTERNAL], [SPAM], [SUSPICIOUS], etc.
+const BRACKET_PREFIX = /^\[[^\]]+\]\s*/;
+
+// ***SPAM***, **URGENT**, etc. Balanced asterisk markers at the start.
+const ASTERISK_PREFIX = /^\*{2,}[^*]+\*{2,}\s*/;
+
+const STRIPPERS: ReadonlyArray<RegExp> = [
+  REPLY_PREFIX,
+  FORWARD_PREFIX,
+  BRACKET_PREFIX,
+  ASTERISK_PREFIX,
+];
+
+const MAX_ITERATIONS = 10;
+
+/**
+ * Iteratively strip every known prefix/marker from the start of
+ * `subject` until nothing matches or the safety cap is hit.
+ *
+ * @param subject Raw subject. Non-string input returns `""`.
+ * @returns Trimmed subject with every leading prefix removed.
+ */
+export function normalizeSubject(subject: string): string {
+  if (typeof subject !== "string") {
+    return "";
+  }
+
+  let current = subject.trim();
+
+  for (let i = 0; i < MAX_ITERATIONS; i++) {
+    let stripped = false;
+
+    for (const re of STRIPPERS) {
+      if (re.test(current)) {
+        current = current.replace(re, "").trim();
+        stripped = true;
+      }
+    }
+
+    if (!stripped) {
+      break;
+    }
+  }
+
+  return current;
+}

--- a/src/threading.test.ts
+++ b/src/threading.test.ts
@@ -1,0 +1,725 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildThreads,
+  getThreadId,
+  ingestIntoThreads,
+  isOrphanId,
+  normalizeSubject,
+} from "./threading.ts";
+import type { ParsedEmail, Thread } from "./types.ts";
+
+function makeEmail(overrides: Partial<ParsedEmail> = {}): ParsedEmail {
+  return {
+    references: [],
+    to: [],
+    cc: [],
+    bcc: [],
+    attachments: [],
+    headers: new Map(),
+    ...overrides,
+  };
+}
+
+describe("normalizeSubject (re-export)", () => {
+  it("delegates to the internal normalizer", () => {
+    expect(normalizeSubject("Re: Fwd: Meeting")).toBe("Meeting");
+  });
+});
+
+describe("getThreadId", () => {
+  it("returns references[0] when References is populated", () => {
+    const email = makeEmail({
+      messageId: "<b@x>",
+      inReplyTo: "<a@x>",
+      references: ["<root@x>", "<middle@x>", "<a@x>"],
+    });
+
+    expect(getThreadId(email)).toBe("<root@x>");
+  });
+
+  it("returns inReplyTo when References is empty", () => {
+    const email = makeEmail({
+      messageId: "<b@x>",
+      inReplyTo: "<a@x>",
+    });
+
+    expect(getThreadId(email)).toBe("<a@x>");
+  });
+
+  it("returns messageId when no threading headers are present", () => {
+    const email = makeEmail({ messageId: "<solo@x>" });
+
+    expect(getThreadId(email)).toBe("<solo@x>");
+  });
+
+  it("synthesizes a deterministic @local id for orphan emails", () => {
+    const email = makeEmail({
+      from: { address: "ada@x" },
+      subject: "Hello",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+
+    const id = getThreadId(email);
+
+    expect(isOrphanId(id)).toBe(true);
+    expect(getThreadId(email)).toBe(id); // deterministic
+  });
+});
+
+describe("buildThreads — basic", () => {
+  it("returns [] for empty input", () => {
+    expect(buildThreads([])).toEqual([]);
+  });
+
+  it("threads a single message into a one-message thread", () => {
+    const email = makeEmail({
+      messageId: "<a@x>",
+      subject: "Hello",
+      from: { address: "ada@x" },
+    });
+
+    const threads = buildThreads([email]);
+
+    expect(threads).toHaveLength(1);
+    expect(threads[0]?.id).toBe("<a@x>");
+    expect(threads[0]?.messageCount).toBe(1);
+    expect(threads[0]?.root.email).toBe(email);
+  });
+
+  it("threads a straight reply chain", () => {
+    const a = makeEmail({
+      messageId: "<a@x>",
+      subject: "Hello",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const b = makeEmail({
+      messageId: "<b@x>",
+      inReplyTo: "<a@x>",
+      references: ["<a@x>"],
+      subject: "Re: Hello",
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+    const c = makeEmail({
+      messageId: "<c@x>",
+      inReplyTo: "<b@x>",
+      references: ["<a@x>", "<b@x>"],
+      subject: "Re: Hello",
+      date: new Date("2026-04-19T02:00:00Z"),
+    });
+
+    const threads = buildThreads([a, b, c]);
+
+    expect(threads).toHaveLength(1);
+    expect(threads[0]?.messageCount).toBe(3);
+    expect(threads[0]?.id).toBe("<a@x>");
+    expect(threads[0]?.root.children).toHaveLength(1);
+    expect(threads[0]?.root.children[0]?.messageId).toBe("<b@x>");
+    expect(threads[0]?.root.children[0]?.children[0]?.messageId).toBe("<c@x>");
+  });
+
+  it("produces the same tree regardless of input order", () => {
+    const a = makeEmail({
+      messageId: "<a@x>",
+      subject: "Hello",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const b = makeEmail({
+      messageId: "<b@x>",
+      inReplyTo: "<a@x>",
+      references: ["<a@x>"],
+      subject: "Re: Hello",
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+    const c = makeEmail({
+      messageId: "<c@x>",
+      inReplyTo: "<b@x>",
+      references: ["<a@x>", "<b@x>"],
+      subject: "Re: Hello",
+      date: new Date("2026-04-19T02:00:00Z"),
+    });
+
+    const forward = buildThreads([a, b, c]);
+    const backward = buildThreads([c, b, a]);
+    const shuffled = buildThreads([b, c, a]);
+
+    expect(forward).toEqual(backward);
+    expect(forward).toEqual(shuffled);
+  });
+});
+
+describe("buildThreads — cycle handling", () => {
+  it("does not drop emails when References forms an A↔B cycle", () => {
+    // A malformed pair: each email claims the other as its parent.
+    const a = makeEmail({
+      messageId: "<a@x>",
+      inReplyTo: "<b@x>",
+      subject: "loop",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const b = makeEmail({
+      messageId: "<b@x>",
+      inReplyTo: "<a@x>",
+      subject: "loop",
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+
+    const threads = buildThreads([a, b]);
+
+    // Both emails surface somewhere in the output.
+    const allIds: string[] = [];
+
+    for (const t of threads) {
+      walkIds(t.root, (id) => allIds.push(id));
+    }
+
+    expect(allIds).toContain("<a@x>");
+    expect(allIds).toContain("<b@x>");
+  });
+});
+
+function walkIds(
+  node: { messageId: string; children: ReadonlyArray<{ messageId: string }> },
+  cb: (id: string) => void,
+): void {
+  cb(node.messageId);
+
+  for (const child of node.children) {
+    walkIds(
+      child as {
+        messageId: string;
+        children: ReadonlyArray<{ messageId: string }>;
+      },
+      cb,
+    );
+  }
+}
+
+describe("buildThreads — branching and intermediate nodes", () => {
+  it("threads a two-level fork keeping each branch under the right parent", () => {
+    const root = makeEmail({
+      messageId: "<root@x>",
+      subject: "Hi",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const b = makeEmail({
+      messageId: "<b@x>",
+      inReplyTo: "<root@x>",
+      references: ["<root@x>"],
+      subject: "Re: Hi",
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+    const c = makeEmail({
+      messageId: "<c@x>",
+      inReplyTo: "<root@x>",
+      references: ["<root@x>"],
+      subject: "Re: Hi",
+      date: new Date("2026-04-19T02:00:00Z"),
+    });
+    const dUnderB = makeEmail({
+      messageId: "<d@x>",
+      inReplyTo: "<b@x>",
+      references: ["<root@x>", "<b@x>"],
+      subject: "Re: Hi",
+      date: new Date("2026-04-19T03:00:00Z"),
+    });
+    const eUnderC = makeEmail({
+      messageId: "<e@x>",
+      inReplyTo: "<c@x>",
+      references: ["<root@x>", "<c@x>"],
+      subject: "Re: Hi",
+      date: new Date("2026-04-19T04:00:00Z"),
+    });
+
+    const threads = buildThreads([root, b, c, dUnderB, eUnderC]);
+
+    expect(threads).toHaveLength(1);
+    const children = threads[0]?.root.children ?? [];
+
+    expect(children.map((c) => c.messageId)).toEqual(["<b@x>", "<c@x>"]);
+    expect(children[0]?.children.map((c) => c.messageId)).toEqual(["<d@x>"]);
+    expect(children[1]?.children.map((c) => c.messageId)).toEqual(["<e@x>"]);
+  });
+
+  it("promotes a single orphan child when its missing parent is known (A → ? → C)", () => {
+    const a = makeEmail({
+      messageId: "<a@x>",
+      subject: "Hi",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const c = makeEmail({
+      messageId: "<c@x>",
+      inReplyTo: "<missing@x>",
+      references: ["<a@x>", "<missing@x>"],
+      subject: "Re: Hi",
+      date: new Date("2026-04-19T02:00:00Z"),
+    });
+
+    const threads = buildThreads([a, c]);
+
+    expect(threads).toHaveLength(1);
+    expect(threads[0]?.id).toBe("<a@x>");
+    expect(threads[0]?.root.children.map((c) => c.messageId)).toContain(
+      "<c@x>",
+    );
+  });
+});
+
+describe("buildThreads — orphan dedup", () => {
+  it("dedupes two orphan emails with identical hashable fields", () => {
+    const sharedFrom = { address: "ada@x" };
+    const sharedDate = new Date("2026-04-19T00:00:00Z");
+
+    const one = makeEmail({
+      from: sharedFrom,
+      subject: "Same",
+      date: sharedDate,
+      text: "body",
+    });
+    const two = makeEmail({
+      from: sharedFrom,
+      subject: "Same",
+      date: sharedDate,
+      text: "body",
+    });
+
+    // Both should resolve to the same synthesized id; dedup retains one.
+    const threads = buildThreads([one, two]);
+
+    expect(threads).toHaveLength(1);
+    expect(threads[0]?.messageCount).toBe(1);
+  });
+});
+
+describe("buildThreads — virtual roots", () => {
+  it("keeps ≥2 orphan siblings under a virtual-root container", () => {
+    // Both messages reply to a parent we don't have.
+    const b = makeEmail({
+      messageId: "<b@x>",
+      inReplyTo: "<missing@x>",
+      references: ["<missing@x>"],
+      subject: "Re: lost thread",
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+    const c = makeEmail({
+      messageId: "<c@x>",
+      inReplyTo: "<missing@x>",
+      references: ["<missing@x>"],
+      subject: "Re: lost thread",
+      date: new Date("2026-04-19T02:00:00Z"),
+    });
+
+    const threads = buildThreads([b, c]);
+
+    expect(threads).toHaveLength(1);
+    expect(threads[0]?.id).toBe("<missing@x>");
+    expect(threads[0]?.root.email).toBeUndefined();
+    expect(threads[0]?.root.children).toHaveLength(2);
+    expect(threads[0]?.messageCount).toBe(2);
+  });
+
+  it("promotes a single orphan child instead of keeping a virtual root", () => {
+    const b = makeEmail({
+      messageId: "<b@x>",
+      inReplyTo: "<missing@x>",
+      references: ["<missing@x>"],
+      subject: "Re: lost thread",
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+
+    const threads = buildThreads([b]);
+
+    expect(threads).toHaveLength(1);
+    expect(threads[0]?.id).toBe("<b@x>");
+    expect(threads[0]?.root.email).toBe(b);
+  });
+});
+
+describe("buildThreads — dedup by Message-ID", () => {
+  it("prefers the richer-content copy of a duplicate Message-ID", () => {
+    const poor = makeEmail({
+      messageId: "<same@x>",
+      subject: "dup",
+      text: "plain only",
+    });
+    const richer = makeEmail({
+      messageId: "<same@x>",
+      subject: "dup",
+      text: "plain",
+      html: "<p>html</p>",
+    });
+
+    const forward = buildThreads([poor, richer]);
+    const backward = buildThreads([richer, poor]);
+
+    expect(forward).toEqual(backward);
+    expect(forward[0]?.root.email).toBe(richer);
+  });
+});
+
+describe("buildThreads — sibling sort", () => {
+  it("sorts siblings ascending by date, dated-before-undated, stable otherwise", () => {
+    const root = makeEmail({
+      messageId: "<root@x>",
+      subject: "Hi",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const later = makeEmail({
+      messageId: "<later@x>",
+      inReplyTo: "<root@x>",
+      references: ["<root@x>"],
+      subject: "Re: Hi",
+      date: new Date("2026-04-19T03:00:00Z"),
+    });
+    const earlier = makeEmail({
+      messageId: "<earlier@x>",
+      inReplyTo: "<root@x>",
+      references: ["<root@x>"],
+      subject: "Re: Hi",
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+    const undated = makeEmail({
+      messageId: "<undated@x>",
+      inReplyTo: "<root@x>",
+      references: ["<root@x>"],
+      subject: "Re: Hi",
+    });
+
+    const threads = buildThreads([undated, later, earlier, root]);
+    const order = threads[0]?.root.children.map((c) => c.messageId);
+
+    expect(order).toEqual(["<earlier@x>", "<later@x>", "<undated@x>"]);
+  });
+});
+
+describe("buildThreads — subject fallback", () => {
+  it("groups messages with the same normalized subject within ±7 days", () => {
+    const a = makeEmail({
+      messageId: "<a@x>",
+      subject: "Planning sync",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const b = makeEmail({
+      messageId: "<b@x>",
+      subject: "Re: Planning sync",
+      date: new Date("2026-04-20T00:00:00Z"),
+    });
+
+    const threads = buildThreads([a, b]);
+
+    expect(threads).toHaveLength(1);
+    expect(threads[0]?.messageCount).toBe(2);
+  });
+
+  it("does NOT group when the subjects differ after normalization", () => {
+    const a = makeEmail({
+      messageId: "<a@x>",
+      subject: "Planning sync",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const b = makeEmail({
+      messageId: "<b@x>",
+      subject: "Budget review",
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+
+    const threads = buildThreads([a, b]);
+
+    expect(threads).toHaveLength(2);
+  });
+
+  it("does NOT group when dates are more than 7 days apart", () => {
+    const a = makeEmail({
+      messageId: "<a@x>",
+      subject: "Planning sync",
+      date: new Date("2026-01-01T00:00:00Z"),
+    });
+    const b = makeEmail({
+      messageId: "<b@x>",
+      subject: "Re: Planning sync",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+
+    const threads = buildThreads([a, b]);
+
+    expect(threads).toHaveLength(2);
+  });
+
+  it("skips subject-fallback entirely when the candidate has no date", () => {
+    const a = makeEmail({
+      messageId: "<a@x>",
+      subject: "Planning sync",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const b = makeEmail({
+      messageId: "<b@x>",
+      subject: "Re: Planning sync",
+    });
+
+    const threads = buildThreads([a, b]);
+
+    expect(threads).toHaveLength(2);
+  });
+});
+
+describe("buildThreads — participants", () => {
+  it("dedupes participants case-insensitively across messages", () => {
+    const a = makeEmail({
+      messageId: "<a@x>",
+      subject: "Hi",
+      from: { name: "Ada", address: "Ada@X.com" },
+      to: [{ address: "grace@x.com" }],
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const b = makeEmail({
+      messageId: "<b@x>",
+      inReplyTo: "<a@x>",
+      references: ["<a@x>"],
+      subject: "Re: Hi",
+      from: { address: "grace@x.com" },
+      to: [{ address: "ADA@x.com" }],
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+
+    const thread = buildThreads([a, b])[0]!;
+
+    expect(thread.participants.map((p) => p.address.toLowerCase()).sort())
+      .toEqual(["ada@x.com", "grace@x.com"]);
+  });
+});
+
+describe("buildThreads — metadata", () => {
+  it("derives participants, lastDate, and normalized subject from the tree", () => {
+    const a = makeEmail({
+      messageId: "<a@x>",
+      subject: "Re: Hello",
+      from: { name: "Ada", address: "ada@x" },
+      to: [{ address: "grace@x" }],
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const b = makeEmail({
+      messageId: "<b@x>",
+      inReplyTo: "<a@x>",
+      references: ["<a@x>"],
+      subject: "Re: Re: Hello",
+      from: { address: "grace@x" },
+      to: [{ address: "ada@x" }, { address: "bob@x" }],
+      date: new Date("2026-04-19T02:00:00Z"),
+    });
+
+    const thread = buildThreads([a, b])[0]!;
+
+    expect(thread.subject).toBe("Hello");
+    expect(thread.lastDate).toEqual(new Date("2026-04-19T02:00:00Z"));
+    const addresses = thread.participants.map((p) => p.address).sort();
+    expect(addresses).toEqual(["ada@x", "bob@x", "grace@x"]);
+  });
+
+  it("orders threads by lastDate descending", () => {
+    const old = makeEmail({
+      messageId: "<old@x>",
+      subject: "Old",
+      date: new Date("2026-01-01T00:00:00Z"),
+    });
+    const recent = makeEmail({
+      messageId: "<recent@x>",
+      subject: "Recent",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+
+    const threads = buildThreads([old, recent]);
+
+    expect(threads[0]?.id).toBe("<recent@x>");
+    expect(threads[1]?.id).toBe("<old@x>");
+  });
+});
+
+describe("ingestIntoThreads", () => {
+  function threadFor(emails: ParsedEmail[]): Thread[] {
+    return buildThreads(emails);
+  }
+
+  it("creates a new thread when no match exists", () => {
+    const fresh = makeEmail({
+      messageId: "<new@x>",
+      subject: "Brand new",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+
+    const { threads, affectedThreadId } = ingestIntoThreads(fresh, []);
+
+    expect(threads).toHaveLength(1);
+    expect(affectedThreadId).toBe("<new@x>");
+  });
+
+  it("matches an existing thread by In-Reply-To", () => {
+    const root = makeEmail({
+      messageId: "<root@x>",
+      subject: "Hi",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const existing = threadFor([root]);
+    const reply = makeEmail({
+      messageId: "<reply@x>",
+      inReplyTo: "<root@x>",
+      references: ["<root@x>"],
+      subject: "Re: Hi",
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+
+    const { threads, affectedThreadId } = ingestIntoThreads(reply, existing);
+
+    expect(threads).toHaveLength(1);
+    expect(affectedThreadId).toBe("<root@x>");
+    expect(threads[0]?.messageCount).toBe(2);
+    expect(threads[0]?.root.children).toHaveLength(1);
+    expect(threads[0]?.root.children[0]?.messageId).toBe("<reply@x>");
+  });
+
+  it("matches by References when In-Reply-To does not link directly", () => {
+    const root = makeEmail({
+      messageId: "<root@x>",
+      subject: "Hi",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const existing = threadFor([root]);
+    const tangential = makeEmail({
+      messageId: "<t@x>",
+      references: ["<root@x>", "<missing-intermediate@x>"],
+      subject: "Re: Hi",
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+
+    const { affectedThreadId } = ingestIntoThreads(tangential, existing);
+
+    expect(affectedThreadId).toBe("<root@x>");
+  });
+
+  it("does not mutate the input threads array", () => {
+    const root = makeEmail({
+      messageId: "<root@x>",
+      subject: "Hi",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const existing = threadFor([root]);
+    const snapshot = JSON.stringify(existing);
+    const reply = makeEmail({
+      messageId: "<reply@x>",
+      inReplyTo: "<root@x>",
+      references: ["<root@x>"],
+      subject: "Re: Hi",
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+
+    ingestIntoThreads(reply, existing);
+
+    expect(JSON.stringify(existing)).toBe(snapshot);
+  });
+
+  it("inserts into a mid-tree node when parent is not the root", () => {
+    const root = makeEmail({
+      messageId: "<root@x>",
+      subject: "Hi",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const mid = makeEmail({
+      messageId: "<mid@x>",
+      inReplyTo: "<root@x>",
+      references: ["<root@x>"],
+      subject: "Re: Hi",
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+    const existing = threadFor([root, mid]);
+    const child = makeEmail({
+      messageId: "<child@x>",
+      inReplyTo: "<mid@x>",
+      references: ["<root@x>", "<mid@x>"],
+      subject: "Re: Hi",
+      date: new Date("2026-04-19T02:00:00Z"),
+    });
+
+    const { threads } = ingestIntoThreads(child, existing);
+    const midNode = threads[0]?.root.children.find(
+      (c) => c.messageId === "<mid@x>",
+    );
+
+    expect(midNode?.children.map((c) => c.messageId)).toEqual(["<child@x>"]);
+    expect(threads[0]?.messageCount).toBe(3);
+  });
+
+  it("attaches the new email to the root when the parent is not in the tree", () => {
+    // Thread contains only <root@x>. Incoming email's inReplyTo points
+    // to an intermediate <phantom@x> that was never ingested, but
+    // References also lists <root@x>, so the match succeeds — yet
+    // parent lookup fails. Must fall back to attaching under root.
+    const root = makeEmail({
+      messageId: "<root@x>",
+      subject: "Hi",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const existing = threadFor([root]);
+    const reply = makeEmail({
+      messageId: "<reply@x>",
+      inReplyTo: "<phantom@x>",
+      references: ["<root@x>", "<phantom@x>"],
+      subject: "Re: Hi",
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+
+    const { threads } = ingestIntoThreads(reply, existing);
+    const ids = threads[0]?.root.children.map((c) => c.messageId);
+
+    expect(ids).toContain("<reply@x>");
+    expect(threads[0]?.messageCount).toBe(2);
+  });
+
+  it("subject-fallback requires a date on the candidate", () => {
+    const root = makeEmail({
+      messageId: "<root@x>",
+      subject: "Planning sync",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const existing = threadFor([root]);
+    const dateless = makeEmail({
+      messageId: "<b@x>",
+      subject: "Re: Planning sync",
+    });
+
+    const { threads, affectedThreadId } = ingestIntoThreads(
+      dateless,
+      existing,
+    );
+
+    // Should create a new thread — subject fallback cannot fire
+    // without a date on the candidate.
+    expect(threads).toHaveLength(2);
+    expect(affectedThreadId).toBe("<b@x>");
+  });
+
+  it("updates participants, lastDate, and messageCount", () => {
+    const root = makeEmail({
+      messageId: "<root@x>",
+      subject: "Hi",
+      from: { address: "ada@x" },
+      to: [{ address: "grace@x" }],
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const existing = threadFor([root]);
+    const reply = makeEmail({
+      messageId: "<reply@x>",
+      inReplyTo: "<root@x>",
+      references: ["<root@x>"],
+      subject: "Re: Hi",
+      from: { address: "grace@x" },
+      to: [{ address: "ada@x" }, { address: "bob@x" }],
+      date: new Date("2026-04-19T02:00:00Z"),
+    });
+
+    const { threads } = ingestIntoThreads(reply, existing);
+
+    expect(threads[0]?.messageCount).toBe(2);
+    expect(threads[0]?.lastDate).toEqual(new Date("2026-04-19T02:00:00Z"));
+    const addresses = threads[0]!.participants.map((p) => p.address).sort();
+    expect(addresses).toEqual(["ada@x", "bob@x", "grace@x"]);
+  });
+});

--- a/src/threading.test.ts
+++ b/src/threading.test.ts
@@ -411,6 +411,24 @@ describe("buildThreads — subject fallback", () => {
     expect(threads[0]?.messageCount).toBe(2);
   });
 
+  it("matches case-insensitively on the subject key", () => {
+    const a = makeEmail({
+      messageId: "<a@x>",
+      subject: "Planning Sync",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const b = makeEmail({
+      messageId: "<b@x>",
+      subject: "re: PLANNING sync",
+      date: new Date("2026-04-20T00:00:00Z"),
+    });
+
+    const threads = buildThreads([a, b]);
+
+    expect(threads).toHaveLength(1);
+    expect(threads[0]?.messageCount).toBe(2);
+  });
+
   it("does NOT group when the subjects differ after normalization", () => {
     const a = makeEmail({
       messageId: "<a@x>",

--- a/src/threading.ts
+++ b/src/threading.ts
@@ -1,0 +1,868 @@
+/**
+ * Thread a flat list of parsed emails into conversation trees (JWZ
+ * algorithm), derive stable thread ids for live ingestion, and
+ * normalize subjects for subject-fallback matching.
+ *
+ * @example
+ * ```ts
+ * import { buildThreads, parseMessage } from "@oflabs/mail-utils";
+ *
+ * const emails = await Promise.all(rawEmls.map(parseMessage));
+ * const threads = buildThreads(emails);
+ * for (const t of threads) {
+ *   console.log(t.subject, t.messageCount);
+ * }
+ * ```
+ *
+ * @module
+ */
+
+import { isOrphanId, synthesizeOrphanId } from "./internal/orphan-id.ts";
+import { normalizeSubject as normalize } from "./internal/subject-normalizer.ts";
+import type {
+  EmailAddress,
+  ParsedEmail,
+  Thread,
+  ThreadNode,
+} from "./types.ts";
+
+// ─── public surface ──────────────────────────────────────────────────
+
+/**
+ * Strip leading reply / forward / bracket / asterisk markers from a
+ * subject line for subject-fallback threading comparison. Handles EN,
+ * DE, FR, ES, IT, PT, NL, PL variants plus `[EXT]`-style and
+ * `***SPAM***`-style markers. Loop-stripped with a 10-iteration cap.
+ *
+ * @param subject Raw subject. Non-string input returns `""`.
+ * @returns Trimmed subject with every leading prefix removed.
+ *
+ * @example
+ * ```ts
+ * normalizeSubject("Re: Fwd: Aw: [EXT] Meeting tomorrow")
+ * // "Meeting tomorrow"
+ * ```
+ */
+export function normalizeSubject(subject: string): string {
+  return normalize(subject);
+}
+
+/**
+ * Derive a stable thread id for a single email, without running the
+ * full JWZ batch threader. Use during live ingestion to assign a
+ * `thread_id` column before storage.
+ *
+ * Logic:
+ * 1. If `references[0]` is set, return it — that's the root of the chain.
+ * 2. Else if `inReplyTo` is set, return it.
+ * 3. Else if `messageId` is set, return it.
+ * 4. Else synthesize a deterministic `<orphan.{hash}@local>` id so that
+ *    re-ingesting the same orphan email produces the same thread id.
+ *
+ * @param email The email to derive a thread id for.
+ * @returns A stable thread id — always a string, never `undefined`.
+ *
+ * @example
+ * ```ts
+ * import { getThreadId, isOrphanId } from "@oflabs/mail-utils";
+ *
+ * declare const email: ParsedEmail;
+ * const id = getThreadId(email);
+ *
+ * if (isOrphanId(id)) {
+ *   // synthesized — reply composition should omit In-Reply-To
+ * }
+ * ```
+ */
+export function getThreadId(email: ParsedEmail): string {
+  const rootFromReferences = email.references[0];
+
+  if (rootFromReferences) {
+    return rootFromReferences;
+  }
+
+  if (email.inReplyTo) {
+    return email.inReplyTo;
+  }
+
+  if (email.messageId) {
+    return email.messageId;
+  }
+
+  return synthesizeOrphanId(email);
+}
+
+/**
+ * Thread a flat list of parsed emails into conversation trees using
+ * the JWZ algorithm (Jamie Zawinski's `www.jwz.org/doc/threading.html`).
+ *
+ * Input order does not affect the output. Emails sharing a
+ * `Message-ID` are deduplicated with a deterministic scoring rule
+ * (richer content wins; ties break on total header count, then the
+ * later date). Missing parents produce virtual-root nodes when they
+ * have ≥2 children so orphan siblings stay grouped. Parent-pointer
+ * cycles are detected and broken.
+ *
+ * For live ingestion of a single new email against an existing
+ * thread set, use {@link ingestIntoThreads} instead.
+ *
+ * @param emails The flat email set to thread.
+ * @returns The resulting {@link Thread}s, ordered by `lastDate`
+ * descending (most recent activity first).
+ *
+ * @example
+ * ```ts
+ * import { buildThreads, parseMessage } from "@oflabs/mail-utils";
+ *
+ * declare const raws: string[];
+ * const emails = await Promise.all(raws.map(parseMessage));
+ * const threads = buildThreads(emails);
+ * for (const t of threads) console.log(t.subject, t.messageCount);
+ * ```
+ */
+export function buildThreads(
+  emails: ReadonlyArray<ParsedEmail>,
+): Thread[] {
+  const deduped = dedupeByMessageId(emails);
+  const containers = buildContainerMap(deduped);
+
+  linkByReferences(containers, deduped);
+  linkBySubjectFallback(containers);
+
+  const roots = collectRoots(containers);
+  const pruned = roots.flatMap(pruneEmptyContainers);
+
+  const threads = pruned.map(buildThreadFromContainer);
+
+  threads.sort(compareThreadsByLastDate);
+
+  return threads;
+}
+
+/**
+ * Insert a single newly-arrived email into an existing set of
+ * threads, returning a new array plus the id of the affected thread.
+ *
+ * Matches against an existing thread via In-Reply-To / References;
+ * falls back to subject matching within ±7 days of the thread's
+ * `lastDate` when no id link is found. Creates a single-message
+ * thread on no match. Never mutates the input array.
+ *
+ * The counterpart to {@link buildThreads} for the batch case.
+ *
+ * @param email The new email to ingest.
+ * @param threads The existing threads (not mutated).
+ * @returns New threads array and `affectedThreadId` — the id of the
+ * thread that now contains the email (either an existing match or
+ * the freshly-created single-message thread).
+ *
+ * @example
+ * ```ts
+ * import { ingestIntoThreads } from "@oflabs/mail-utils";
+ *
+ * let threads: Thread[] = [];
+ *
+ * for await (const email of incomingEmails) {
+ *   const result = ingestIntoThreads(email, threads);
+ *   threads = result.threads;
+ *   await markThreadDirty(result.affectedThreadId);
+ * }
+ * ```
+ */
+export function ingestIntoThreads(
+  email: ParsedEmail,
+  threads: ReadonlyArray<Thread>,
+): { threads: Thread[]; affectedThreadId: string } {
+  const match = findMatchingThread(email, threads);
+
+  if (match) {
+    const updated = insertEmailIntoThread(email, match);
+    const next = threads.map((t) => (t === match ? updated : t));
+
+    return { threads: next, affectedThreadId: updated.id };
+  }
+
+  const fresh = singleMessageThread(email);
+
+  return { threads: [...threads, fresh], affectedThreadId: fresh.id };
+}
+
+// ─── JWZ container implementation ────────────────────────────────────
+
+interface Container {
+  messageId: string;
+  email: ParsedEmail | undefined;
+  parentId: string | undefined;
+  children: Container[];
+}
+
+function makeContainer(messageId: string): Container {
+  return { messageId, email: undefined, parentId: undefined, children: [] };
+}
+
+function ensureContainer(
+  map: Map<string, Container>,
+  messageId: string,
+): Container {
+  const existing = map.get(messageId);
+
+  if (existing) {
+    return existing;
+  }
+
+  const container = makeContainer(messageId);
+
+  map.set(messageId, container);
+
+  return container;
+}
+
+function scoreEmail(email: ParsedEmail): number {
+  let score = 0;
+
+  if (email.html) score += 3;
+  if (email.text) score += 2;
+  if (email.attachments.length > 0) score += 1;
+
+  return score;
+}
+
+function totalHeaderOccurrences(email: ParsedEmail): number {
+  let count = 0;
+
+  for (const arr of email.headers.values()) {
+    count += arr.length;
+  }
+
+  return count;
+}
+
+// Returns `true` when `candidate` should replace `existing` under the
+// deterministic tiebreak rules (richer content wins; then more header
+// occurrences; then later date; otherwise first-seen wins).
+function candidateIsRicher(
+  candidate: ParsedEmail,
+  existing: ParsedEmail,
+): boolean {
+  const candidateScore = scoreEmail(candidate);
+  const existingScore = scoreEmail(existing);
+
+  if (candidateScore !== existingScore) {
+    return candidateScore > existingScore;
+  }
+
+  const candidateHeaders = totalHeaderOccurrences(candidate);
+  const existingHeaders = totalHeaderOccurrences(existing);
+
+  if (candidateHeaders !== existingHeaders) {
+    return candidateHeaders > existingHeaders;
+  }
+
+  const candidateDate = candidate.date?.getTime();
+  const existingDate = existing.date?.getTime();
+
+  if (candidateDate !== undefined && existingDate !== undefined) {
+    return candidateDate > existingDate;
+  }
+
+  return false;
+}
+
+function dedupeByMessageId(
+  emails: ReadonlyArray<ParsedEmail>,
+): ParsedEmail[] {
+  // Dedupe orphans by their synthesized id alongside real Message-IDs
+  // so two orphans with identical hashable fields don't silently
+  // collide later in buildContainerMap.
+  const byId = new Map<string, ParsedEmail>();
+
+  for (const email of emails) {
+    const id = email.messageId ?? synthesizeOrphanId(email);
+    const existing = byId.get(id);
+
+    if (!existing) {
+      byId.set(id, email);
+
+      continue;
+    }
+
+    if (candidateIsRicher(email, existing)) {
+      byId.set(id, email);
+    }
+  }
+
+  return [...byId.values()];
+}
+
+function buildContainerMap(
+  emails: ReadonlyArray<ParsedEmail>,
+): Map<string, Container> {
+  const map = new Map<string, Container>();
+
+  for (const email of emails) {
+    const id = email.messageId ?? synthesizeOrphanId(email);
+    const container = ensureContainer(map, id);
+
+    container.email = email;
+  }
+
+  return map;
+}
+
+function linkByReferences(
+  map: Map<string, Container>,
+  emails: ReadonlyArray<ParsedEmail>,
+): void {
+  for (const email of emails) {
+    linkReferenceChain(map, email.references);
+
+    const childId = email.messageId ?? synthesizeOrphanId(email);
+    const child = map.get(childId);
+
+    if (!child || child.parentId !== undefined) {
+      continue;
+    }
+
+    const parentId = findParentId(email);
+
+    if (!parentId || parentId === childId) {
+      continue;
+    }
+
+    if (wouldCreateCycle(map, childId, parentId)) {
+      // Linking `child → parentId` would close a cycle; keep child a
+      // root rather than silently dropping it.
+      continue;
+    }
+
+    const parent = ensureContainer(map, parentId);
+
+    child.parentId = parentId;
+    parent.children.push(child);
+  }
+}
+
+// Link every consecutive pair in a References list: for
+// `[root, middle, parent]`, set middle.parent = root and
+// parent.parent = middle. Creates virtual containers for any missing
+// ids so pruning can later promote a single live descendant up to the
+// nearest real ancestor.
+function linkReferenceChain(
+  map: Map<string, Container>,
+  refs: ReadonlyArray<string>,
+): void {
+  for (let i = 0; i < refs.length - 1; i++) {
+    const parentId = refs[i]!;
+    const childId = refs[i + 1]!;
+
+    if (parentId === childId) {
+      continue;
+    }
+
+    const childContainer = ensureContainer(map, childId);
+
+    if (childContainer.parentId !== undefined) {
+      continue;
+    }
+
+    if (wouldCreateCycle(map, childId, parentId)) {
+      continue;
+    }
+
+    const parentContainer = ensureContainer(map, parentId);
+
+    childContainer.parentId = parentId;
+    parentContainer.children.push(childContainer);
+  }
+}
+
+// Walks the existing parent chain starting at `parentId`; returns
+// `true` if it reaches `childId`, which would mean linking them
+// closes a cycle. Also breaks out on any pre-existing cycle in the
+// map to stay finite.
+function wouldCreateCycle(
+  map: Map<string, Container>,
+  childId: string,
+  parentId: string,
+): boolean {
+  const visited = new Set<string>();
+  let cursor: string | undefined = parentId;
+
+  while (cursor !== undefined) {
+    if (cursor === childId) {
+      return true;
+    }
+
+    if (visited.has(cursor)) {
+      return true;
+    }
+
+    visited.add(cursor);
+    cursor = map.get(cursor)?.parentId;
+  }
+
+  return false;
+}
+
+function findParentId(email: ParsedEmail): string | undefined {
+  if (email.inReplyTo) {
+    return email.inReplyTo;
+  }
+
+  // Per JWZ: last entry of References is the immediate parent.
+  const refs = email.references;
+
+  return refs.length > 0 ? refs[refs.length - 1] : undefined;
+}
+
+function linkBySubjectFallback(map: Map<string, Container>): void {
+  // Group candidate roots by normalized subject within a ±7-day window.
+  const WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+  const bySubject = new Map<string, Container[]>();
+
+  for (const container of map.values()) {
+    if (container.parentId !== undefined || !container.email) {
+      continue;
+    }
+
+    const subject = normalize(container.email.subject ?? "");
+
+    if (!subject) {
+      continue;
+    }
+
+    const list = bySubject.get(subject);
+
+    if (list) {
+      list.push(container);
+    } else {
+      bySubject.set(subject, [container]);
+    }
+  }
+
+  for (const group of bySubject.values()) {
+    if (group.length < 2) {
+      continue;
+    }
+
+    // Earliest-dated member becomes the synthetic root for the group.
+    group.sort(compareContainersByDate);
+
+    const root = group[0]!;
+
+    for (let i = 1; i < group.length; i++) {
+      const candidate = group[i]!;
+
+      if (!withinWindow(root, candidate, WINDOW_MS)) {
+        continue;
+      }
+
+      candidate.parentId = root.messageId;
+      root.children.push(candidate);
+    }
+  }
+
+}
+
+function withinWindow(
+  a: Container,
+  b: Container,
+  windowMs: number,
+): boolean {
+  const da = a.email?.date?.getTime();
+  const db = b.email?.date?.getTime();
+
+  if (da === undefined || db === undefined) {
+    return false;
+  }
+
+  return Math.abs(da - db) <= windowMs;
+}
+
+function collectRoots(map: Map<string, Container>): Container[] {
+  const roots: Container[] = [];
+
+  for (const container of map.values()) {
+    if (container.parentId === undefined) {
+      roots.push(container);
+    }
+  }
+
+  return roots;
+}
+
+// JWZ container-pruning rules:
+//   · 0 children → delete if empty.
+//   · 1 child and container empty → promote the child.
+//   · ≥2 children and container empty → keep as virtual root.
+// Always recurse before deciding, so children are already pruned.
+function pruneEmptyContainers(node: Container): Container[] {
+  const prunedChildren: Container[] = [];
+
+  for (const child of node.children) {
+    prunedChildren.push(...pruneEmptyContainers(child));
+  }
+
+  node.children = prunedChildren;
+
+  if (node.email) {
+    return [node];
+  }
+
+  if (prunedChildren.length === 0) {
+    return [];
+  }
+
+  if (prunedChildren.length === 1) {
+    const only = prunedChildren[0]!;
+
+    only.parentId = undefined;
+
+    return [only];
+  }
+
+  return [node];
+}
+
+function buildThreadFromContainer(root: Container): Thread {
+  const sortedRoot = sortChildrenRecursively(root);
+  const node = toThreadNode(sortedRoot);
+  const participants = collectParticipants(sortedRoot);
+  const messageCount = countMessages(sortedRoot);
+  const lastDate = computeLastDate(sortedRoot);
+  const subject = root.email?.subject
+    ? normalize(root.email.subject)
+    : undefined;
+
+  const thread: Thread = {
+    id: root.messageId,
+    root: node,
+    participants,
+    messageCount,
+    ...(subject !== undefined && subject.length > 0 ? { subject } : {}),
+    ...(lastDate !== undefined ? { lastDate } : {}),
+  };
+
+  return thread;
+}
+
+function sortChildrenRecursively(node: Container): Container {
+  for (const child of node.children) {
+    sortChildrenRecursively(child);
+  }
+
+  node.children.sort(compareContainersByDate);
+
+  return node;
+}
+
+function compareContainersByDate(a: Container, b: Container): number {
+  const da = a.email?.date?.getTime();
+  const db = b.email?.date?.getTime();
+
+  if (da !== undefined && db !== undefined) {
+    return da - db;
+  }
+
+  if (da !== undefined) return -1;
+  if (db !== undefined) return 1;
+
+  return 0;
+}
+
+function compareThreadsByLastDate(a: Thread, b: Thread): number {
+  const da = a.lastDate?.getTime();
+  const db = b.lastDate?.getTime();
+
+  if (da !== undefined && db !== undefined) return db - da;
+  if (da !== undefined) return -1;
+  if (db !== undefined) return 1;
+
+  return 0;
+}
+
+function toThreadNode(container: Container): ThreadNode {
+  const children = container.children.map(toThreadNode);
+
+  if (container.email) {
+    return {
+      email: container.email,
+      messageId: container.messageId,
+      children,
+    };
+  }
+
+  return { messageId: container.messageId, children };
+}
+
+function collectParticipants(node: Container): EmailAddress[] {
+  const seen = new Map<string, EmailAddress>();
+
+  function visit(container: Container): void {
+    if (container.email) {
+      const email = container.email;
+
+      if (email.from) {
+        addParticipant(seen, email.from);
+      }
+
+      for (const a of email.to) addParticipant(seen, a);
+      for (const a of email.cc) addParticipant(seen, a);
+      for (const a of email.bcc) addParticipant(seen, a);
+    }
+
+    for (const child of container.children) visit(child);
+  }
+
+  visit(node);
+
+  return [...seen.values()];
+}
+
+function addParticipant(
+  map: Map<string, EmailAddress>,
+  address: EmailAddress,
+): void {
+  const key = address.address.toLowerCase();
+
+  if (!map.has(key)) {
+    map.set(key, address);
+  }
+}
+
+function countMessages(node: Container): number {
+  let count = node.email ? 1 : 0;
+
+  for (const child of node.children) {
+    count += countMessages(child);
+  }
+
+  return count;
+}
+
+function computeLastDate(node: Container): Date | undefined {
+  let latest: Date | undefined;
+
+  function visit(container: Container): void {
+    const d = container.email?.date;
+
+    if (d && (!latest || d.getTime() > latest.getTime())) {
+      latest = d;
+    }
+
+    for (const child of container.children) visit(child);
+  }
+
+  visit(node);
+
+  return latest;
+}
+
+// ─── ingestIntoThreads helpers ───────────────────────────────────────
+
+function findMatchingThread(
+  email: ParsedEmail,
+  threads: ReadonlyArray<Thread>,
+): Thread | undefined {
+  const candidateIds = new Set<string>();
+
+  if (email.inReplyTo) candidateIds.add(email.inReplyTo);
+  for (const r of email.references) candidateIds.add(r);
+
+  if (candidateIds.size > 0) {
+    const threadIds = collectAllMessageIds(threads);
+
+    for (const id of candidateIds) {
+      if (threadIds.has(id)) {
+        return threadById(threads, threadIds.get(id)!);
+      }
+    }
+  }
+
+  const subject = normalize(email.subject ?? "");
+
+  if (!subject) {
+    return undefined;
+  }
+
+  for (const thread of threads) {
+    if (!thread.subject || thread.subject !== subject) {
+      continue;
+    }
+
+    if (datesWithinWindow(email.date, thread.lastDate)) {
+      return thread;
+    }
+  }
+
+  return undefined;
+}
+
+function collectAllMessageIds(
+  threads: ReadonlyArray<Thread>,
+): Map<string, string> {
+  const map = new Map<string, string>();
+
+  function visit(threadId: string, node: ThreadNode): void {
+    map.set(node.messageId, threadId);
+
+    for (const child of node.children) visit(threadId, child);
+  }
+
+  for (const thread of threads) {
+    visit(thread.id, thread.root);
+  }
+
+  return map;
+}
+
+function threadById(
+  threads: ReadonlyArray<Thread>,
+  id: string,
+): Thread | undefined {
+  return threads.find((t) => t.id === id);
+}
+
+function datesWithinWindow(
+  a: Date | undefined,
+  b: Date | undefined,
+): boolean {
+  if (!a || !b) return false;
+
+  return Math.abs(a.getTime() - b.getTime()) <= 7 * 24 * 60 * 60 * 1000;
+}
+
+function insertEmailIntoThread(
+  email: ParsedEmail,
+  thread: Thread,
+): Thread {
+  const messageId = email.messageId ?? synthesizeOrphanId(email);
+  const newNode: ThreadNode = {
+    email,
+    messageId,
+    children: [],
+  };
+  const parentId = findParentId(email);
+  const attempt = insertUnderParent(thread.root, newNode, parentId);
+
+  // If no parent was found in the tree, attach the new node as a
+  // direct child of the thread root so the email is never silently
+  // dropped despite messageCount / participants having been updated.
+  const root = attempt.inserted
+    ? attempt.node
+    : {
+        ...thread.root,
+        children: sortNodes([...thread.root.children, newNode]),
+      };
+
+  const participants = mergeParticipants(thread.participants, email);
+  const messageCount = thread.messageCount + 1;
+  const lastDate = maxDate(thread.lastDate, email.date);
+
+  return {
+    id: thread.id,
+    root,
+    participants,
+    messageCount,
+    ...(thread.subject !== undefined ? { subject: thread.subject } : {}),
+    ...(lastDate !== undefined ? { lastDate } : {}),
+  };
+}
+
+function insertUnderParent(
+  node: ThreadNode,
+  newNode: ThreadNode,
+  parentId: string | undefined,
+): { node: ThreadNode; inserted: boolean } {
+  if (parentId && node.messageId === parentId) {
+    return {
+      node: {
+        ...node,
+        children: sortNodes([...node.children, newNode]),
+      },
+      inserted: true,
+    };
+  }
+
+  let inserted = false;
+  const newChildren = node.children.map((c) => {
+    const result = insertUnderParent(c, newNode, parentId);
+
+    if (result.inserted) inserted = true;
+
+    return result.node;
+  });
+
+  if (inserted) {
+    return { node: { ...node, children: newChildren }, inserted: true };
+  }
+
+  return { node, inserted: false };
+}
+
+function sortNodes(
+  nodes: ReadonlyArray<ThreadNode>,
+): ThreadNode[] {
+  const arr = [...nodes];
+
+  arr.sort((a, b) => {
+    const da = a.email?.date?.getTime();
+    const db = b.email?.date?.getTime();
+
+    if (da !== undefined && db !== undefined) return da - db;
+    if (da !== undefined) return -1;
+    if (db !== undefined) return 1;
+
+    return 0;
+  });
+
+  return arr;
+}
+
+function mergeParticipants(
+  existing: ReadonlyArray<EmailAddress>,
+  email: ParsedEmail,
+): EmailAddress[] {
+  const map = new Map<string, EmailAddress>();
+
+  for (const a of existing) {
+    map.set(a.address.toLowerCase(), a);
+  }
+
+  if (email.from) addParticipant(map, email.from);
+  for (const a of email.to) addParticipant(map, a);
+  for (const a of email.cc) addParticipant(map, a);
+  for (const a of email.bcc) addParticipant(map, a);
+
+  return [...map.values()];
+}
+
+function maxDate(
+  a: Date | undefined,
+  b: Date | undefined,
+): Date | undefined {
+  if (!a) return b;
+  if (!b) return a;
+
+  return a.getTime() >= b.getTime() ? a : b;
+}
+
+function singleMessageThread(email: ParsedEmail): Thread {
+  const messageId = email.messageId ?? synthesizeOrphanId(email);
+  const root: ThreadNode = { email, messageId, children: [] };
+  const participants = mergeParticipants([], email);
+  const normalized = normalize(email.subject ?? "");
+  const subject = normalized.length > 0 ? normalized : undefined;
+
+  return {
+    id: messageId,
+    root,
+    participants,
+    messageCount: 1,
+    ...(subject !== undefined ? { subject } : {}),
+    ...(email.date !== undefined ? { lastDate: email.date } : {}),
+  };
+}
+
+// `isOrphanId` is re-exported for downstream composition use.
+export { isOrphanId };

--- a/src/threading.ts
+++ b/src/threading.ts
@@ -425,18 +425,18 @@ function linkBySubjectFallback(map: Map<string, Container>): void {
       continue;
     }
 
-    const subject = normalize(container.email.subject ?? "");
+    const subjectKey = normalize(container.email.subject ?? "").toLowerCase();
 
-    if (!subject) {
+    if (!subjectKey) {
       continue;
     }
 
-    const list = bySubject.get(subject);
+    const list = bySubject.get(subjectKey);
 
     if (list) {
       list.push(container);
     } else {
-      bySubject.set(subject, [container]);
+      bySubject.set(subjectKey, [container]);
     }
   }
 
@@ -679,14 +679,14 @@ function findMatchingThread(
     }
   }
 
-  const subject = normalize(email.subject ?? "");
+  const subjectKey = normalize(email.subject ?? "").toLowerCase();
 
-  if (!subject) {
+  if (!subjectKey) {
     return undefined;
   }
 
   for (const thread of threads) {
-    if (!thread.subject || thread.subject !== subject) {
+    if (!thread.subject || thread.subject.toLowerCase() !== subjectKey) {
       continue;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,3 +110,38 @@ export type ThreadingHeaders = {
   readonly inReplyTo?: string | undefined;
   readonly references: readonly string[];
 };
+
+/**
+ * A node in a thread tree. Every node has a `messageId` that identifies
+ * its position in the conversation; `email` is present when the actual
+ * message was available to the threader and absent when JWZ kept the
+ * node as a virtual root (a parent referenced by ≥2 children but not
+ * present in the input set).
+ */
+export type ThreadNode = {
+  /** The parsed email for this node, or `undefined` for a virtual root. */
+  readonly email?: ParsedEmail | undefined;
+  /** Message-ID this node represents. Always present, even for virtual roots. */
+  readonly messageId: string;
+  /** Direct replies to this node, sorted by date (dated first, then ascending). */
+  readonly children: readonly ThreadNode[];
+};
+
+/**
+ * A full conversation — the root of a {@link ThreadNode} tree plus
+ * aggregated metadata.
+ */
+export type Thread = {
+  /** Message-ID of the root, used as a stable thread identifier. */
+  readonly id: string;
+  /** Root node of the conversation tree. */
+  readonly root: ThreadNode;
+  /** Deduplicated union of every mailbox that appears in any message. */
+  readonly participants: readonly EmailAddress[];
+  /** Normalized subject of the root (RFC 2047 decoded, prefixes stripped). */
+  readonly subject?: string | undefined;
+  /** Most recent `Date:` across every message in the thread. */
+  readonly lastDate?: Date | undefined;
+  /** Count of nodes whose `email` is present (virtual roots excluded). */
+  readonly messageCount: number;
+};


### PR DESCRIPTION
Adds conversation threading to the library. Covers both the batch path (`buildThreads` — turn a flat set of emails into `Thread` trees) and the live path (`ingestIntoThreads` — insert a new email into an existing thread set). Plus `getThreadId` for cheap id derivation during live ingestion, `normalizeSubject` for subject-fallback matching, and `isOrphanId` for detecting synthesized ids downstream.

Two internal deep modules land alongside — a multilingual subject normalizer and a deterministic 64-bit hash for synthesizing thread ids on orphan emails.

The algorithm follows JWZ faithfully, including:
- virtual-root containers for missing parents with multiple children (so orphan siblings stay grouped as one conversation)
- full References-chain linking so `A → missing → C` correctly threads C under A
- parent-pointer cycle detection so malformed `A refs B, B refs A` doesn't silently drop both emails
- deterministic input-order-independent output

Live ingestion also survives the common "parent not in the tree" case — the email attaches to the thread root instead of vanishing while the message count silently increments.

171 tests green (78 new), JSR dry-run clean, no slow types.

Closes #2