### PR TITLE
Implement composition module

### DIFF
--- a/src/composition.test.ts
+++ b/src/composition.test.ts
@@ -1,0 +1,673 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildReferences,
+  createDraft,
+  createForward,
+  createReply,
+  createReplyAll,
+  generateMessageId,
+  quoteBody,
+} from "./composition.ts";
+import { parseMessage } from "./parsing.ts";
+import type { Attachment, ParsedEmail } from "./types.ts";
+
+function makeEmail(overrides: Partial<ParsedEmail> = {}): ParsedEmail {
+  return {
+    references: [],
+    to: [],
+    cc: [],
+    bcc: [],
+    attachments: [],
+    headers: new Map(),
+    ...overrides,
+  };
+}
+
+function makeAttachment(overrides: Partial<Attachment> = {}): Attachment {
+  const content = new ArrayBuffer(5);
+
+  new Uint8Array(content).set([104, 105, 33, 33, 33]); // "hi!!!"
+
+  return {
+    mimeType: "text/plain",
+    disposition: "attachment",
+    size: 5,
+    content,
+    ...overrides,
+  };
+}
+
+describe("re-exports from internal modules", () => {
+  it("generateMessageId delegates", () => {
+    expect(generateMessageId("example.com")).toMatch(/@example\.com>$/);
+  });
+
+  it("buildReferences delegates", () => {
+    const email = makeEmail({
+      messageId: "<a@x>",
+      references: [],
+    });
+
+    expect(buildReferences(email)).toEqual(["<a@x>"]);
+  });
+
+  it("quoteBody delegates", () => {
+    const email = makeEmail({
+      from: { address: "ada@x" },
+      text: "hi",
+    });
+
+    const result = quoteBody(email);
+
+    expect(result.text).toContain("ada@x wrote:");
+    expect(result.html).toContain("<blockquote>");
+  });
+});
+
+describe("createReply", () => {
+  const from = { name: "Me", address: "me@example.com" };
+
+  it("replies to the original sender only", () => {
+    const incoming = makeEmail({
+      messageId: "<abc@example.com>",
+      from: { address: "ada@example.com" },
+      to: [{ address: "other@example.com" }],
+      subject: "Hello",
+      text: "hi there",
+      date: new Date("2026-04-19T12:00:00Z"),
+    });
+
+    const reply = createReply(incoming, {
+      from,
+      body: { text: "Thanks!" },
+    });
+
+    expect(reply.to).toEqual([{ address: "ada@example.com" }]);
+    expect(reply.cc).toEqual([]);
+    expect(reply.subject).toBe("Re: Hello");
+    expect(reply.inReplyTo).toBe("<abc@example.com>");
+    expect(reply.references).toEqual(["<abc@example.com>"]);
+    expect(reply.text).toContain("Thanks!");
+    expect(reply.text).toContain("> hi there");
+  });
+
+  it("prefers replyTo over from when present", () => {
+    const incoming = makeEmail({
+      messageId: "<abc@x>",
+      from: { address: "ada@x" },
+      replyTo: { address: "support@x" },
+      subject: "Hi",
+      text: "body",
+    });
+
+    const reply = createReply(incoming, { from, body: { text: "ok" } });
+
+    expect(reply.to).toEqual([{ address: "support@x" }]);
+  });
+
+  it("does not add Re: when the subject already has a reply prefix", () => {
+    const incoming = makeEmail({
+      messageId: "<abc@x>",
+      from: { address: "ada@x" },
+      subject: "Re: Hi",
+      text: "body",
+    });
+
+    const reply = createReply(incoming, { from, body: { text: "ok" } });
+
+    expect(reply.subject).toBe("Re: Hi");
+  });
+
+  it("strips excluded addresses from the recipient list", () => {
+    const incoming = makeEmail({
+      messageId: "<abc@x>",
+      from: { address: "me@example.com" },
+      subject: "Hi",
+      text: "body",
+    });
+
+    const reply = createReply(incoming, {
+      from,
+      body: { text: "ok" },
+      excludeAddresses: ["ME@example.com"],
+    });
+
+    expect(reply.to).toEqual([]);
+  });
+
+  it("omits In-Reply-To when the original message-id is a synthesized orphan", () => {
+    const incoming = makeEmail({
+      messageId: "<orphan.0123456789abcdef@local>",
+      from: { address: "ada@x" },
+      subject: "Hi",
+      text: "body",
+    });
+
+    const reply = createReply(incoming, { from, body: { text: "ok" } });
+
+    expect(reply.inReplyTo).toBeUndefined();
+  });
+});
+
+describe("createReplyAll", () => {
+  const from = { name: "Me", address: "me@example.com" };
+
+  it("replies to sender + original To, deduped; original Cc becomes Cc", () => {
+    const incoming = makeEmail({
+      messageId: "<abc@x>",
+      from: { address: "ada@example.com" },
+      to: [{ address: "grace@example.com" }, { address: "bob@example.com" }],
+      cc: [{ address: "charlie@example.com" }],
+      subject: "Hi",
+      text: "body",
+    });
+
+    const reply = createReplyAll(incoming, { from, body: { text: "ok" } });
+
+    expect(reply.to.map((a) => a.address).sort()).toEqual([
+      "ada@example.com",
+      "bob@example.com",
+      "grace@example.com",
+    ]);
+    expect(reply.cc.map((a) => a.address)).toEqual(["charlie@example.com"]);
+  });
+
+  it("removes To entries from the Cc list after dedup", () => {
+    const incoming = makeEmail({
+      messageId: "<abc@x>",
+      from: { address: "ada@example.com" },
+      to: [{ address: "grace@example.com" }],
+      cc: [{ address: "grace@example.com" }, { address: "bob@example.com" }],
+      subject: "Hi",
+      text: "body",
+    });
+
+    const reply = createReplyAll(incoming, { from, body: { text: "ok" } });
+
+    expect(reply.cc.map((a) => a.address)).toEqual(["bob@example.com"]);
+  });
+
+  it("strips excluded addresses from both To and Cc", () => {
+    const incoming = makeEmail({
+      messageId: "<abc@x>",
+      from: { address: "ada@example.com" },
+      to: [{ address: "me@example.com" }],
+      cc: [{ address: "ME@example.com" }],
+      subject: "Hi",
+      text: "body",
+    });
+
+    const reply = createReplyAll(incoming, {
+      from,
+      body: { text: "ok" },
+      excludeAddresses: ["me@example.com"],
+    });
+
+    expect(reply.to.map((a) => a.address)).toEqual(["ada@example.com"]);
+    expect(reply.cc).toEqual([]);
+  });
+
+  it("allows the recipient set to end up empty", () => {
+    const incoming = makeEmail({
+      messageId: "<abc@x>",
+      from: { address: "me@example.com" },
+      subject: "Hi",
+      text: "body",
+    });
+
+    const reply = createReplyAll(incoming, {
+      from,
+      body: { text: "ok" },
+      excludeAddresses: ["me@example.com"],
+    });
+
+    expect(reply.to).toEqual([]);
+    expect(reply.cc).toEqual([]);
+  });
+});
+
+describe("createForward", () => {
+  const from = { name: "Me", address: "me@example.com" };
+
+  it("adds Fwd: prefix, copies attachments, preserves References", () => {
+    const original = makeEmail({
+      messageId: "<abc@example.com>",
+      from: { address: "ada@example.com" },
+      subject: "Quarterly plan",
+      text: "see attached",
+      references: ["<root@example.com>"],
+      attachments: [makeAttachment({ filename: "plan.pdf" })],
+    });
+
+    const forwarded = createForward(original, {
+      from,
+      to: [{ address: "colleague@example.com" }],
+    });
+
+    expect(forwarded.subject).toBe("Fwd: Quarterly plan");
+    expect(forwarded.inReplyTo).toBeUndefined();
+    expect(forwarded.references).toEqual([
+      "<root@example.com>",
+      "<abc@example.com>",
+    ]);
+    expect(forwarded.attachments).toHaveLength(1);
+    expect(forwarded.attachments[0]?.filename).toBe("plan.pdf");
+    expect(forwarded.text).toContain("---------- Forwarded message ----------");
+    expect(forwarded.text).toContain("ada@example.com");
+  });
+
+  it("does not double-add Fwd: when the subject already has a forward prefix", () => {
+    const original = makeEmail({
+      messageId: "<abc@x>",
+      from: { address: "ada@x" },
+      subject: "Fwd: Quarterly",
+      attachments: [],
+    });
+
+    const forwarded = createForward(original, {
+      from,
+      to: [{ address: "colleague@x" }],
+    });
+
+    expect(forwarded.subject).toBe("Fwd: Quarterly");
+  });
+
+  it("throws when any attachment is missing content", () => {
+    const original = makeEmail({
+      messageId: "<abc@x>",
+      from: { address: "ada@x" },
+      attachments: [
+        {
+          mimeType: "application/pdf",
+          disposition: "attachment",
+          size: 1000,
+          filename: "plan.pdf",
+          content: undefined,
+        },
+      ],
+    });
+
+    expect(() =>
+      createForward(original, { from, to: [{ address: "c@x" }] }),
+    ).toThrow(/createForward requires Attachment\.content/);
+  });
+});
+
+describe("createDraft", () => {
+  const from = { name: "Me", address: "me@example.com" };
+
+  it("creates a fresh outbound message with no threading context", () => {
+    const draft = createDraft({
+      from,
+      to: [{ address: "friend@example.com" }],
+      subject: "Hello",
+      body: { text: "Hi there!" },
+    });
+
+    expect(draft.inReplyTo).toBeUndefined();
+    expect(draft.references).toEqual([]);
+    expect(draft.subject).toBe("Hello");
+    expect(draft.to).toEqual([{ address: "friend@example.com" }]);
+    expect(draft.messageId).toMatch(/@example\.com>$/);
+  });
+
+  it("defaults subject to empty string", () => {
+    const draft = createDraft({ from });
+
+    expect(draft.subject).toBe("");
+  });
+
+  it("carries attachments through", () => {
+    const draft = createDraft({
+      from,
+      to: [{ address: "friend@x" }],
+      attachments: [makeAttachment({ filename: "a.bin" })],
+    });
+
+    expect(draft.attachments).toHaveLength(1);
+    expect(draft.attachments[0]?.filename).toBe("a.bin");
+  });
+
+  it("accepts bcc in the structured field", () => {
+    const draft = createDraft({
+      from,
+      to: [{ address: "a@x" }],
+      bcc: [{ address: "archive@x" }],
+    });
+
+    expect(draft.bcc).toEqual([{ address: "archive@x" }]);
+  });
+});
+
+describe("Bcc never leaks into raw", () => {
+  const from = { address: "me@example.com" };
+
+  it("createDraft.raw does not contain Bcc: header", () => {
+    const draft = createDraft({
+      from,
+      to: [{ address: "a@example.com" }],
+      bcc: [{ address: "archive@example.com" }],
+      subject: "Hi",
+      body: { text: "hello" },
+    });
+
+    expect(draft.raw).not.toMatch(/^Bcc:/im);
+    expect(draft.raw).not.toContain("archive@example.com");
+  });
+
+  it("createReply.raw does not contain Bcc: header", () => {
+    const incoming = makeEmail({
+      messageId: "<abc@x>",
+      from: { address: "ada@x" },
+      subject: "Hi",
+      text: "body",
+    });
+
+    const reply = createReply(incoming, {
+      from,
+      body: { text: "ok" },
+    });
+
+    expect(reply.raw).not.toMatch(/^Bcc:/im);
+  });
+
+  it("createReplyAll.raw does not contain Bcc: header", () => {
+    const incoming = makeEmail({
+      messageId: "<abc@x>",
+      from: { address: "ada@x" },
+      to: [{ address: "grace@x" }],
+      subject: "Hi",
+      text: "body",
+    });
+
+    const reply = createReplyAll(incoming, {
+      from,
+      body: { text: "ok" },
+    });
+
+    expect(reply.raw).not.toMatch(/^Bcc:/im);
+  });
+
+  it("createForward.raw does not contain Bcc: header", () => {
+    const original = makeEmail({
+      messageId: "<abc@x>",
+      from: { address: "ada@x" },
+      subject: "Hi",
+      attachments: [],
+    });
+
+    const forwarded = createForward(original, {
+      from,
+      to: [{ address: "c@x" }],
+    });
+
+    expect(forwarded.raw).not.toMatch(/^Bcc:/im);
+  });
+});
+
+describe("raw round-trips through parseMessage", () => {
+  const from = { name: "Me", address: "me@example.com" };
+
+  it("createDraft → parse preserves headers and body", async () => {
+    const draft = createDraft({
+      from,
+      to: [{ address: "grace@example.com" }],
+      subject: "Hello",
+      body: { text: "Hi Grace!" },
+    });
+
+    const parsed = await parseMessage(draft.raw);
+
+    expect(parsed.messageId).toBe(draft.messageId);
+    expect(parsed.subject).toBe("Hello");
+    expect(parsed.from?.address).toBe("me@example.com");
+    expect(parsed.to[0]?.address).toBe("grace@example.com");
+    expect(parsed.text?.trim()).toBe("Hi Grace!");
+  });
+
+  it("createReply → parse preserves threading headers", async () => {
+    const incoming = makeEmail({
+      messageId: "<abc@example.com>",
+      from: { address: "ada@example.com" },
+      subject: "Hi",
+      text: "original body",
+      references: ["<root@example.com>"],
+    });
+
+    const reply = createReply(incoming, { from, body: { text: "Thanks." } });
+    const parsed = await parseMessage(reply.raw);
+
+    expect(parsed.subject).toBe("Re: Hi");
+    expect(parsed.inReplyTo).toBe("<abc@example.com>");
+    expect(parsed.references).toEqual([
+      "<root@example.com>",
+      "<abc@example.com>",
+    ]);
+  });
+
+  it("createForward → parse preserves attachment metadata and content", async () => {
+    const content = new ArrayBuffer(5);
+
+    new Uint8Array(content).set([104, 105, 33, 33, 33]); // "hi!!!"
+
+    const original = makeEmail({
+      messageId: "<abc@example.com>",
+      from: { address: "ada@example.com" },
+      subject: "Quarterly plan",
+      text: "see attached",
+      attachments: [
+        {
+          filename: "plan.bin",
+          mimeType: "application/octet-stream",
+          disposition: "attachment",
+          size: 5,
+          content,
+        },
+      ],
+    });
+
+    const forwarded = createForward(original, {
+      from,
+      to: [{ address: "colleague@example.com" }],
+    });
+
+    const parsed = await parseMessage(forwarded.raw);
+
+    expect(parsed.subject).toBe("Fwd: Quarterly plan");
+    expect(parsed.attachments).toHaveLength(1);
+    expect(parsed.attachments[0]?.filename).toBe("plan.bin");
+    expect(parsed.attachments[0]?.size).toBe(5);
+  });
+});
+
+describe("multi-language Re: / Fwd: prefix detection", () => {
+  const from = { address: "me@example.com" };
+
+  it.each([
+    ["Re: Hi"],
+    ["RE: Hi"],
+    ["Aw: Hallo"],
+    ["Rép: Bonjour"],
+    ["RV: Hola"],
+    ["Sv: Hej"],
+    ["Antw: Hallo"],
+    ["Odp: Cześć"],
+  ])("createReply does not double-add prefix on %s", (subject) => {
+    const incoming = makeEmail({
+      messageId: "<abc@x>",
+      from: { address: "ada@x" },
+      subject,
+      text: "body",
+    });
+
+    const reply = createReply(incoming, { from, body: { text: "ok" } });
+
+    expect(reply.subject).toBe(subject);
+  });
+
+  it.each([
+    ["Fwd: Plan"],
+    ["FWD: Plan"],
+    ["Fw: Plan"],
+    ["Wg: Plan"],
+    ["Tr: Plan"],
+    ["Doorst: Plan"],
+    ["Vs: Plan"],
+  ])("createForward does not double-add prefix on %s", (subject) => {
+    const original = makeEmail({
+      messageId: "<abc@x>",
+      from: { address: "ada@x" },
+      subject,
+      attachments: [],
+    });
+
+    const forwarded = createForward(original, {
+      from,
+      to: [{ address: "c@x" }],
+    });
+
+    expect(forwarded.subject).toBe(subject);
+  });
+});
+
+describe("createForward body emission", () => {
+  const from = { address: "me@example.com" };
+
+  it("does not emit an HTML body when forwarding a text-only original with no user html", () => {
+    const original = makeEmail({
+      messageId: "<abc@x>",
+      from: { address: "ada@x" },
+      subject: "Text only",
+      text: "plain content",
+      attachments: [],
+    });
+
+    const forwarded = createForward(original, {
+      from,
+      to: [{ address: "c@x" }],
+    });
+
+    expect(forwarded.html).toBeUndefined();
+    expect(forwarded.text).toBeDefined();
+  });
+
+  it("emits both sides when the original had both or the user provided both", () => {
+    const original = makeEmail({
+      messageId: "<abc@x>",
+      from: { address: "ada@x" },
+      subject: "Mixed",
+      text: "plain",
+      html: "<p>html</p>",
+      attachments: [],
+    });
+
+    const forwarded = createForward(original, {
+      from,
+      to: [{ address: "c@x" }],
+      body: { text: "note", html: "<p>note</p>" },
+    });
+
+    expect(forwarded.html).toBeDefined();
+    expect(forwarded.text).toBeDefined();
+  });
+});
+
+describe("createDraft attachment validation", () => {
+  const from = { address: "me@example.com" };
+
+  it("throws when any attachment is missing content", () => {
+    expect(() =>
+      createDraft({
+        from,
+        to: [{ address: "a@x" }],
+        attachments: [
+          {
+            mimeType: "application/pdf",
+            disposition: "attachment",
+            size: 100,
+            filename: "plan.pdf",
+            content: undefined,
+          },
+        ],
+      }),
+    ).toThrow(/createDraft requires Attachment\.content/);
+  });
+});
+
+describe("domainFor validation", () => {
+  it("throws when from.address has no `@`", () => {
+    expect(() =>
+      createDraft({
+        from: { address: "localpart-only" },
+        to: [{ address: "a@x.com" }],
+      }),
+    ).toThrow(/must contain a domain/);
+  });
+
+  it("throws when from.address ends with `@`", () => {
+    expect(() =>
+      createDraft({
+        from: { address: "ada@" },
+        to: [{ address: "a@x.com" }],
+      }),
+    ).toThrow(/non-empty domain/);
+  });
+});
+
+describe("raw serialization", () => {
+  const from = { name: "Me", address: "me@example.com" };
+
+  it("uses CRLF line endings per SMTP", () => {
+    const draft = createDraft({
+      from,
+      to: [{ address: "a@example.com" }],
+      subject: "Hi",
+      body: { text: "hello" },
+    });
+
+    // Every newline must be CRLF.
+    expect(draft.raw).not.toMatch(/(?<!\r)\n/);
+  });
+
+  it("includes Message-ID, From, and To headers", () => {
+    const draft = createDraft({
+      from,
+      to: [{ address: "a@example.com" }],
+      subject: "Hi",
+    });
+
+    expect(draft.raw).toContain(`Message-ID: ${draft.messageId}`);
+    expect(draft.raw).toContain("From:");
+    expect(draft.raw).toContain("a@example.com");
+  });
+
+  it("emits a Date: header (per RFC 5322)", () => {
+    const draft = createDraft({
+      from,
+      to: [{ address: "a@example.com" }],
+      subject: "Hi",
+      body: { text: "hello" },
+    });
+
+    expect(draft.raw).toMatch(/^Date:/im);
+  });
+
+  it("includes In-Reply-To and References when set", () => {
+    const original = makeEmail({
+      messageId: "<abc@x>",
+      from: { address: "ada@x" },
+      references: ["<root@x>"],
+      subject: "Hi",
+      text: "hi",
+    });
+
+    const reply = createReply(original, {
+      from,
+      body: { text: "ok" },
+    });
+
+    expect(reply.raw).toContain("In-Reply-To: <abc@x>");
+    expect(reply.raw).toContain("References: <root@x> <abc@x>");
+  });
+});

--- a/src/composition.ts
+++ b/src/composition.ts
@@ -1,0 +1,547 @@
+/**
+ * Compose outbound emails — replies, reply-alls, forwards, and
+ * brand-new drafts — producing a structured {@link ComposedMessage}
+ * whose `raw` field is wire-ready for any SMTP transport.
+ *
+ * `raw` intentionally excludes the `Bcc:` header so passing the same
+ * serialized form to every recipient does not leak BCC addresses.
+ * Callers drive envelope-level BCC delivery via the structured
+ * {@link ComposedMessage.bcc} field.
+ *
+ * @example
+ * ```ts
+ * import { createReply, parseMessage } from "@oflabs/mail-utils";
+ *
+ * declare const rawEml: string;
+ * const incoming = await parseMessage(rawEml);
+ * const reply = createReply(incoming, {
+ *   from: { name: "Ada", address: "ada@example.com" },
+ *   body: { text: "Thanks — looks good." },
+ * });
+ * await transport.send(reply.raw, reply.bcc);
+ * ```
+ *
+ * @module
+ */
+
+import { createMimeMessage } from "mimetext/browser";
+import type { MailboxAddrObject } from "mimetext";
+
+import { deduplicateAddresses, excludeAddresses } from "./addressing.ts";
+import { generateMessageId as generateId } from "./internal/message-id.ts";
+import { quoteBody as quoteBodyImpl } from "./internal/quote-body.ts";
+import { buildReferences as buildRefs } from "./internal/references-builder.ts";
+import {
+  hasForwardPrefix,
+  hasReplyPrefix,
+} from "./internal/subject-normalizer.ts";
+import { isOrphanId } from "./internal/orphan-id.ts";
+import type {
+  Attachment,
+  ComposedMessage,
+  DraftOptions,
+  EmailAddress,
+  ForwardOptions,
+  ParsedEmail,
+  ReplyOptions,
+} from "./types.ts";
+
+// ─── public re-exports of deep-module helpers ────────────────────────
+
+/**
+ * Generate a globally unique RFC 5322 Message-ID of the form
+ * `<unix_ms.hex16@domain>`. Uses `globalThis.crypto.getRandomValues`
+ * so it runs unchanged in any JavaScript runtime.
+ *
+ * @param domain The right-hand side of the `@` in the Message-ID —
+ * typically your sending domain.
+ * @returns A new Message-ID including angle brackets.
+ * @throws {Error} When `domain` is empty, non-string, or contains
+ * whitespace or `<>@` characters — caller error, not bad email data.
+ */
+export function generateMessageId(domain: string): string {
+  return generateId(domain);
+}
+
+/**
+ * Build the `References:` header array for a reply or forward.
+ *
+ * Concatenates `original.references` with `original.messageId` (if
+ * present), deduplicates while preserving order, then caps the chain
+ * at 20 entries by keeping the first 3 and last 17. The truncation
+ * keeps the conversation's root id in place (so threading still
+ * anchors) while preserving the most-recent chain (so the immediate
+ * reply target is intact), and keeps the serialized header short
+ * enough that relays won't truncate or mangle it.
+ *
+ * @param original The message being replied to or forwarded.
+ * @returns A fresh `References` array ready to hand to composition.
+ */
+export function buildReferences(original: ParsedEmail): string[] {
+  return buildRefs(original);
+}
+
+/**
+ * Format the original message as an HTML blockquote and a `> `-prefixed
+ * text quote with attribution. Missing `from` or `date` are handled
+ * gracefully — attribution is omitted entirely when both are absent.
+ *
+ * Note: `original.html` is embedded verbatim; the library does not
+ * sanitize. The downstream caller is responsible for HTML sanitization
+ * at rendering time. See also {@link createReply} and {@link createForward}.
+ *
+ * @param original The message to quote.
+ * @returns HTML + text representations of the quote block.
+ */
+export function quoteBody(original: ParsedEmail): {
+  html: string;
+  text: string;
+} {
+  return quoteBodyImpl(original);
+}
+
+// ─── public composition functions ────────────────────────────────────
+
+/**
+ * Build a reply addressed to the original sender only.
+ *
+ * - `To:` is set from `original.replyTo`, falling back to
+ *   `original.from`. An `excludeAddresses` entry matching either one
+ *   removes it; the result may legitimately be empty.
+ * - `In-Reply-To:` is set to `original.messageId`, unless the id is a
+ *   synthesized orphan id (detected via {@link isOrphanId}), in which
+ *   case it is omitted — synthesized ids have no real counterpart and
+ *   would make no sense as a reply target.
+ * - `References:` is built via {@link buildReferences}.
+ * - Subject gets a leading `Re: ` unless the subject already carries a
+ *   reply prefix in any supported language.
+ * - Body is `options.body` followed by a blank line and the output of
+ *   {@link quoteBody}.
+ *
+ * See also {@link createReplyAll}, {@link createForward}.
+ *
+ * @param original The message being replied to.
+ * @param options Reply configuration.
+ * @returns The composed reply.
+ * @throws {Error} When `options.from` has no domain.
+ */
+export function createReply(
+  original: ParsedEmail,
+  options: ReplyOptions,
+): ComposedMessage {
+  const primary = original.replyTo ?? original.from;
+  const to = primary ? [primary] : [];
+  const excluded = options.excludeAddresses ?? [];
+  const filteredTo = excludeAddresses(to, excluded);
+
+  const subject = ensureReplyPrefix(original.subject ?? "");
+  const references = buildRefs(original);
+  const messageId = generateId(domainFor(options.from));
+  const inReplyTo =
+    original.messageId && !isOrphanId(original.messageId)
+      ? original.messageId
+      : undefined;
+
+  const body = combineBodyWithQuote(options.body, quoteBodyImpl(original));
+
+  return finalizeComposed({
+    messageId,
+    inReplyTo,
+    references,
+    subject,
+    from: options.from,
+    to: filteredTo,
+    cc: [],
+    bcc: [],
+    html: body.html,
+    text: body.text,
+    attachments: [],
+  });
+}
+
+/**
+ * Build a reply addressed to every non-BCC participant of the original
+ * message except anyone listed in `excludeAddresses` (typically your
+ * own address, to avoid replying to yourself).
+ *
+ * Recipients are deduplicated across `To` and `Cc`, case-insensitively.
+ * The `Cc` list is also trimmed of any address that already appears in
+ * `To`. When every recipient would be excluded, both lists come back
+ * empty — the caller decides whether to send.
+ *
+ * Follows the same `In-Reply-To` omission rule as {@link createReply}:
+ * synthesized orphan ids are skipped.
+ *
+ * @param original The message being replied to.
+ * @param options Reply configuration.
+ * @returns The composed reply.
+ * @throws {Error} When `options.from` has no domain.
+ */
+export function createReplyAll(
+  original: ParsedEmail,
+  options: ReplyOptions,
+): ComposedMessage {
+  const primary = original.replyTo ?? original.from;
+  const primaryList: EmailAddress[] = primary ? [primary] : [];
+  const combinedTo = deduplicateAddresses([...primaryList, ...original.to]);
+  const combinedCc = deduplicateAddresses([...original.cc]);
+
+  const excluded = options.excludeAddresses ?? [];
+  const filteredTo = excludeAddresses(combinedTo, excluded);
+  const filteredCcBeforeToDedup = excludeAddresses(combinedCc, excluded);
+
+  const toAddresses = new Set(
+    filteredTo.map((addr) => addr.address.toLowerCase()),
+  );
+  const finalCc = filteredCcBeforeToDedup.filter(
+    (addr) => !toAddresses.has(addr.address.toLowerCase()),
+  );
+
+  const subject = ensureReplyPrefix(original.subject ?? "");
+  const references = buildRefs(original);
+  const messageId = generateId(domainFor(options.from));
+  const inReplyTo =
+    original.messageId && !isOrphanId(original.messageId)
+      ? original.messageId
+      : undefined;
+
+  const body = combineBodyWithQuote(options.body, quoteBodyImpl(original));
+
+  return finalizeComposed({
+    messageId,
+    inReplyTo,
+    references,
+    subject,
+    from: options.from,
+    to: filteredTo,
+    cc: finalCc,
+    bcc: [],
+    html: body.html,
+    text: body.text,
+    attachments: [],
+  });
+}
+
+/**
+ * Build a forward — a new message with the original content attached
+ * inline as a quoted block plus the original's attachments carried
+ * into the outgoing MIME body.
+ *
+ * Style: "quoted forward" (body contains an attribution header and
+ * the quoted original). Does not set `In-Reply-To` — a forward is a
+ * new conversational thread from the recipient's perspective. Keeps
+ * the `References` chain so the forwarded thread remains linkable for
+ * archival purposes.
+ *
+ * @param original The message being forwarded.
+ * @param options Forward configuration.
+ * @returns The composed forward.
+ * @throws {Error} When `options.from` has no domain, or any original
+ * attachment is missing its `content` — caller error, since silent
+ * attachment loss is worse than failing loudly.
+ */
+export function createForward(
+  original: ParsedEmail,
+  options: ForwardOptions,
+): ComposedMessage {
+  for (const att of original.attachments) {
+    if (att.content === undefined) {
+      throw new Error(
+        "createForward requires Attachment.content on all attachments",
+      );
+    }
+  }
+
+  const subject = ensureForwardPrefix(original.subject ?? "");
+  const references = buildRefs(original);
+  const messageId = generateId(domainFor(options.from));
+  const quoted = quoteBodyImpl(original);
+  const attribution = buildForwardAttribution(original);
+  const body = combineBodyWithForwardedBlock(
+    options.body ?? {},
+    attribution,
+    quoted,
+    original,
+  );
+
+  return finalizeComposed({
+    messageId,
+    references,
+    subject,
+    from: options.from,
+    to: options.to,
+    cc: options.cc ?? [],
+    bcc: [],
+    html: body.html,
+    text: body.text,
+    attachments: [...original.attachments],
+  });
+}
+
+/**
+ * Build a brand-new outbound message with no threading context.
+ * Generates a fresh Message-ID, sets no `In-Reply-To`, and starts
+ * `References` empty.
+ *
+ * @param options Draft configuration.
+ * @returns The composed message, including a serialized `raw` form.
+ * @throws {Error} When `options.from` has no domain, or any attachment
+ * in `options.attachments` is missing its `content`.
+ */
+export function createDraft(options: DraftOptions): ComposedMessage {
+  const attachments = options.attachments ?? [];
+
+  for (const att of attachments) {
+    if (att.content === undefined) {
+      throw new Error(
+        "createDraft requires Attachment.content on all attachments",
+      );
+    }
+  }
+
+  const messageId = generateId(domainFor(options.from));
+  const body = options.body ?? {};
+
+  return finalizeComposed({
+    messageId,
+    references: [],
+    subject: options.subject ?? "",
+    from: options.from,
+    to: options.to ?? [],
+    cc: options.cc ?? [],
+    bcc: options.bcc ?? [],
+    html: body.html,
+    text: body.text,
+    attachments: [...attachments],
+  });
+}
+
+// ─── internals ───────────────────────────────────────────────────────
+
+type ComposedDraft = Omit<ComposedMessage, "raw">;
+
+function finalizeComposed(draft: ComposedDraft): ComposedMessage {
+  return { ...draft, raw: serializeToRaw(draft) };
+}
+
+function domainFor(address: EmailAddress): string {
+  const parts = address.address.split("@");
+
+  if (parts.length < 2) {
+    throw new Error("options.from must contain a domain (`local@domain`)");
+  }
+
+  const last = parts[parts.length - 1];
+
+  if (!last || last.length === 0) {
+    throw new Error(
+      "options.from must contain a non-empty domain after `@`",
+    );
+  }
+
+  return last;
+}
+
+function ensureReplyPrefix(subject: string): string {
+  const trimmed = subject.trim();
+
+  if (hasReplyPrefix(trimmed)) {
+    return trimmed;
+  }
+
+  return trimmed.length > 0 ? `Re: ${trimmed}` : "Re:";
+}
+
+function ensureForwardPrefix(subject: string): string {
+  const trimmed = subject.trim();
+
+  if (hasForwardPrefix(trimmed)) {
+    return trimmed;
+  }
+
+  return trimmed.length > 0 ? `Fwd: ${trimmed}` : "Fwd:";
+}
+
+function combineBodyWithQuote(
+  userBody: { html?: string | undefined; text?: string | undefined },
+  quote: { html: string; text: string },
+): { html: string | undefined; text: string | undefined } {
+  const html =
+    userBody.html !== undefined || quote.html.length > 0
+      ? `${userBody.html ?? ""}\n\n${quote.html}`
+      : undefined;
+  const text =
+    userBody.text !== undefined || quote.text.length > 0
+      ? `${userBody.text ?? ""}\n\n${quote.text}`
+      : undefined;
+
+  return { html, text };
+}
+
+function buildForwardAttribution(original: ParsedEmail): string {
+  const lines = ["---------- Forwarded message ----------"];
+
+  if (original.from) {
+    const from = original.from.name
+      ? `${original.from.name} <${original.from.address}>`
+      : original.from.address;
+
+    lines.push(`From: ${from}`);
+  }
+
+  if (original.date) {
+    lines.push(`Date: ${original.date.toISOString()}`);
+  }
+
+  if (original.subject) {
+    lines.push(`Subject: ${original.subject}`);
+  }
+
+  if (original.to.length > 0) {
+    lines.push(
+      `To: ${original.to
+        .map((a) => (a.name ? `${a.name} <${a.address}>` : a.address))
+        .join(", ")}`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function combineBodyWithForwardedBlock(
+  userBody: { html?: string | undefined; text?: string | undefined },
+  attribution: string,
+  quote: { html: string; text: string },
+  original: ParsedEmail,
+): { html: string | undefined; text: string | undefined } {
+  const userWantsHtml = userBody.html !== undefined;
+  const userWantsText = userBody.text !== undefined;
+  const originalHasHtml = original.html !== undefined;
+  const originalHasText = original.text !== undefined;
+
+  // Emit the html side only when the caller provided html or the
+  // original carried html. Otherwise a text-only forward would pick
+  // up a synthetic HTML body it never asked for.
+  const html =
+    userWantsHtml || originalHasHtml
+      ? [
+          userBody.html ?? "",
+          "",
+          `<pre>${escapeForPre(attribution)}</pre>`,
+          quote.html,
+        ].join("\n")
+      : undefined;
+
+  // Same logic for text.
+  const text =
+    userWantsText || originalHasText
+      ? [userBody.text ?? "", "", attribution, "", quote.text].join("\n")
+      : undefined;
+
+  return { html, text };
+}
+
+function escapeForPre(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+// ─── raw serialization via mimetext ──────────────────────────────────
+
+function toMailbox(address: EmailAddress): MailboxAddrObject {
+  if (address.name && address.name.length > 0) {
+    return { addr: address.address, name: address.name };
+  }
+
+  return { addr: address.address };
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+
+  return btoa(binary);
+}
+
+function attachMimetextAttachment(
+  msg: ReturnType<typeof createMimeMessage>,
+  att: Attachment,
+): void {
+  if (att.content === undefined) {
+    return;
+  }
+
+  const headers: Record<string, string> = {};
+
+  if (att.contentId) {
+    headers["Content-ID"] = att.contentId;
+  }
+
+  msg.addAttachment({
+    filename: att.filename ?? "attachment",
+    contentType: att.mimeType,
+    data: arrayBufferToBase64(att.content),
+    inline: att.disposition === "inline",
+    headers,
+  });
+}
+
+function serializeToRaw(draft: ComposedDraft): string {
+  const msg = createMimeMessage();
+
+  msg.setSender(toMailbox(draft.from));
+
+  if (draft.to.length > 0) {
+    msg.setTo(draft.to.map(toMailbox));
+  }
+
+  if (draft.cc.length > 0) {
+    msg.setCc(draft.cc.map(toMailbox));
+  }
+
+  // Intentional: Bcc is NEVER written into raw. Callers use the
+  // structured `bcc` field for envelope-level delivery.
+
+  // mimetext rejects empty-subject messages; pass a single-space when
+  // the caller left it blank so the header is still emitted.
+  msg.setSubject(draft.subject.length > 0 ? draft.subject : " ");
+
+  msg.setHeader("Message-ID", draft.messageId);
+
+  if (draft.inReplyTo) {
+    msg.setHeader("In-Reply-To", draft.inReplyTo);
+  }
+
+  if (draft.references.length > 0) {
+    msg.setHeader("References", draft.references.join(" "));
+  }
+
+  // mimetext requires at least one body part. If neither text nor
+  // html was supplied, fall back to an empty text/plain body.
+  if (draft.text === undefined && draft.html === undefined) {
+    msg.addMessage({ contentType: "text/plain", data: "" });
+  } else {
+    if (draft.text !== undefined) {
+      msg.addMessage({ contentType: "text/plain", data: draft.text });
+    }
+
+    if (draft.html !== undefined) {
+      msg.addMessage({ contentType: "text/html", data: draft.html });
+    }
+  }
+
+  for (const att of draft.attachments) {
+    attachMimetextAttachment(msg, att);
+  }
+
+  const raw = msg.asRaw();
+
+  // Enforce CRLF per SMTP regardless of mimetext's EOL choice.
+  return raw.replace(/\r?\n/g, "\r\n");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,12 @@
 
 export type {
   Attachment,
+  ComposedMessage,
+  DraftOptions,
   EmailAddress,
+  ForwardOptions,
   ParsedEmail,
+  ReplyOptions,
   Thread,
   ThreadingHeaders,
   ThreadNode,
@@ -51,3 +55,13 @@ export {
   isOrphanId,
   normalizeSubject,
 } from "./threading.ts";
+
+export {
+  buildReferences,
+  createDraft,
+  createForward,
+  createReply,
+  createReplyAll,
+  generateMessageId,
+  quoteBody,
+} from "./composition.ts";

--- a/src/internal/message-id.test.ts
+++ b/src/internal/message-id.test.ts
@@ -39,6 +39,18 @@ describe("generateMessageId", () => {
     expect(id.endsWith("@example.com>")).toBe(true);
   });
 
+  it("normalizes IDN domains to punycode", () => {
+    const id = generateMessageId("münchen.de");
+
+    expect(id.endsWith("@xn--mnchen-3ya.de>")).toBe(true);
+  });
+
+  it("lowercases ASCII domains", () => {
+    const id = generateMessageId("Example.COM");
+
+    expect(id.endsWith("@example.com>")).toBe(true);
+  });
+
   it.each([
     ["empty string", ""],
     ["only whitespace", "   "],

--- a/src/internal/message-id.test.ts
+++ b/src/internal/message-id.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { generateMessageId } from "./message-id.ts";
+
+describe("generateMessageId", () => {
+  it("produces ids of the documented shape", () => {
+    const id = generateMessageId("example.com");
+
+    expect(id).toMatch(/^<\d{10,}\.[0-9a-f]{16}@example\.com>$/);
+  });
+
+  it("is statistically unique over many iterations", () => {
+    const ids = new Set<string>();
+
+    for (let i = 0; i < 2000; i++) {
+      ids.add(generateMessageId("example.com"));
+    }
+
+    expect(ids.size).toBe(2000);
+  });
+
+  it("embeds the current timestamp", () => {
+    const before = Date.now();
+    const id = generateMessageId("example.com");
+    const after = Date.now();
+
+    const match = id.match(/^<(\d+)\./);
+
+    expect(match).not.toBeNull();
+    const ts = Number(match![1]);
+
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it("trims whitespace around the domain", () => {
+    const id = generateMessageId("  example.com  ");
+
+    expect(id.endsWith("@example.com>")).toBe(true);
+  });
+
+  it.each([
+    ["empty string", ""],
+    ["only whitespace", "   "],
+    ["contains space", "exam ple.com"],
+    ["contains <", "exam<ple.com"],
+    ["contains >", "exam>ple.com"],
+    ["contains @", "exam@ple.com"],
+  ])("throws on invalid domain: %s", (_label, domain) => {
+    expect(() => generateMessageId(domain)).toThrow();
+  });
+
+  it("throws on non-string domain", () => {
+    // @ts-expect-error — intentional runtime misuse.
+    expect(() => generateMessageId(undefined)).toThrow();
+    // @ts-expect-error — intentional runtime misuse.
+    expect(() => generateMessageId(123)).toThrow();
+  });
+});

--- a/src/internal/message-id.ts
+++ b/src/internal/message-id.ts
@@ -1,0 +1,49 @@
+/**
+ * Generate RFC 5322 Message-IDs of the form `<unix_ms.hex16@domain>`.
+ *
+ * Internal module; re-exported publicly as `generateMessageId` from
+ * `../composition.ts`.
+ *
+ * @module
+ */
+
+const INVALID_DOMAIN_CHARS = /[\s<>@]/;
+
+/**
+ * Format: `<{unix_ms}.{16_hex_chars}@{domain}>`.
+ *
+ * The 8 random bytes come from `globalThis.crypto.getRandomValues` so
+ * the function runs unchanged in Workers, Node, Deno, Bun, and
+ * browsers. Throws on invalid `domain` — that's caller error, not bad
+ * email data, and the rule #3 "no throws" contract explicitly does
+ * not cover it.
+ */
+export function generateMessageId(domain: string): string {
+  if (typeof domain !== "string") {
+    throw new Error("generateMessageId: domain must be a string");
+  }
+
+  const trimmed = domain.trim();
+
+  if (trimmed.length === 0) {
+    throw new Error("generateMessageId: domain must be non-empty");
+  }
+
+  if (INVALID_DOMAIN_CHARS.test(trimmed)) {
+    throw new Error(
+      "generateMessageId: domain cannot contain whitespace or `<>@` characters",
+    );
+  }
+
+  const bytes = new Uint8Array(8);
+
+  globalThis.crypto.getRandomValues(bytes);
+
+  let hex = "";
+
+  for (let i = 0; i < bytes.length; i++) {
+    hex += (bytes[i] ?? 0).toString(16).padStart(2, "0");
+  }
+
+  return `<${Date.now()}.${hex}@${trimmed}>`;
+}

--- a/src/internal/message-id.ts
+++ b/src/internal/message-id.ts
@@ -9,14 +9,27 @@
 
 const INVALID_DOMAIN_CHARS = /[\s<>@]/;
 
+function toAsciiDomain(input: string): string {
+  // Run the candidate through the WHATWG URL parser, which handles
+  // IDN (punycode) conversion and lowercasing. Fall back to the raw
+  // input when parsing fails — the caller's separate validation
+  // below will then reject it.
+  try {
+    return new URL(`http://${input}`).hostname;
+  } catch {
+    return input;
+  }
+}
+
 /**
  * Format: `<{unix_ms}.{16_hex_chars}@{domain}>`.
  *
  * The 8 random bytes come from `globalThis.crypto.getRandomValues` so
  * the function runs unchanged in Workers, Node, Deno, Bun, and
- * browsers. Throws on invalid `domain` — that's caller error, not bad
- * email data, and the rule #3 "no throws" contract explicitly does
- * not cover it.
+ * browsers. Internationalized (IDN) domains are normalized via the
+ * WHATWG URL API — `"münchen.de"` becomes `"xn--mnchen-3ya.de"`.
+ *
+ * Throws on invalid `domain` (caller error, not bad email data).
  */
 export function generateMessageId(domain: string): string {
   if (typeof domain !== "string") {
@@ -29,10 +42,18 @@ export function generateMessageId(domain: string): string {
     throw new Error("generateMessageId: domain must be non-empty");
   }
 
+  // Validate the raw input before normalization — the URL parser is
+  // permissive enough to treat `exam@ple.com` as `userinfo@host`.
   if (INVALID_DOMAIN_CHARS.test(trimmed)) {
     throw new Error(
       "generateMessageId: domain cannot contain whitespace or `<>@` characters",
     );
+  }
+
+  const normalized = toAsciiDomain(trimmed);
+
+  if (normalized.length === 0 || INVALID_DOMAIN_CHARS.test(normalized)) {
+    throw new Error("generateMessageId: domain failed normalization");
   }
 
   const bytes = new Uint8Array(8);
@@ -45,5 +66,5 @@ export function generateMessageId(domain: string): string {
     hex += (bytes[i] ?? 0).toString(16).padStart(2, "0");
   }
 
-  return `<${Date.now()}.${hex}@${trimmed}>`;
+  return `<${Date.now()}.${hex}@${normalized}>`;
 }

--- a/src/internal/quote-body.test.ts
+++ b/src/internal/quote-body.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import { quoteBody } from "./quote-body.ts";
+import type { ParsedEmail } from "../types.ts";
+
+function makeEmail(overrides: Partial<ParsedEmail> = {}): ParsedEmail {
+  return {
+    references: [],
+    to: [],
+    cc: [],
+    bcc: [],
+    attachments: [],
+    headers: new Map(),
+    ...overrides,
+  };
+}
+
+describe("quoteBody — attribution", () => {
+  it("uses from.name when present", () => {
+    const result = quoteBody(
+      makeEmail({
+        from: { name: "Ada", address: "ada@x" },
+        date: new Date("2026-04-19T12:00:00Z"),
+        text: "hi",
+      }),
+    );
+
+    expect(result.text).toContain(
+      "On 2026-04-19T12:00:00.000Z, Ada wrote:",
+    );
+  });
+
+  it("falls back to from.address when name is missing", () => {
+    const result = quoteBody(
+      makeEmail({
+        from: { address: "ada@x" },
+        date: new Date("2026-04-19T12:00:00Z"),
+        text: "hi",
+      }),
+    );
+
+    expect(result.text).toContain(
+      "On 2026-04-19T12:00:00.000Z, ada@x wrote:",
+    );
+  });
+
+  it("drops date when only from is present", () => {
+    const result = quoteBody(
+      makeEmail({ from: { address: "ada@x" }, text: "hi" }),
+    );
+
+    expect(result.text).toContain("ada@x wrote:");
+    expect(result.text).not.toContain("On undefined");
+  });
+
+  it("uses `someone` when only date is present", () => {
+    const result = quoteBody(
+      makeEmail({ date: new Date("2026-04-19T12:00:00Z"), text: "hi" }),
+    );
+
+    expect(result.text).toContain(
+      "On 2026-04-19T12:00:00.000Z, someone wrote:",
+    );
+  });
+
+  it("omits the attribution line entirely when both from and date are missing", () => {
+    const result = quoteBody(makeEmail({ text: "hi" }));
+
+    expect(result.text.startsWith(">")).toBe(true);
+    expect(result.html.startsWith("<blockquote>")).toBe(true);
+  });
+});
+
+describe("quoteBody — HTML source", () => {
+  it("uses original.html when present", () => {
+    const result = quoteBody(
+      makeEmail({
+        from: { address: "ada@x" },
+        html: "<p>Hello <b>world</b></p>",
+      }),
+    );
+
+    expect(result.html).toContain("<blockquote><p>Hello <b>world</b></p></blockquote>");
+  });
+
+  it("converts text to simple HTML when html is absent", () => {
+    const result = quoteBody(
+      makeEmail({
+        from: { address: "ada@x" },
+        text: "line1\nline2 <with> & \"special\" chars",
+      }),
+    );
+
+    expect(result.html).toContain("line1<br>");
+    expect(result.html).toContain("&lt;with&gt;");
+    expect(result.html).toContain("&amp;");
+    expect(result.html).toContain("&quot;special&quot;");
+  });
+});
+
+describe("quoteBody — text quote", () => {
+  it("prefixes every line with `> `", () => {
+    const result = quoteBody(
+      makeEmail({ from: { address: "ada@x" }, text: "line1\nline2\nline3" }),
+    );
+
+    expect(result.text).toContain("> line1\n> line2\n> line3");
+  });
+
+  it("handles empty text gracefully", () => {
+    const result = quoteBody(
+      makeEmail({ from: { address: "ada@x" }, text: "" }),
+    );
+
+    expect(result.text).toContain("ada@x wrote:");
+  });
+});

--- a/src/internal/quote-body.ts
+++ b/src/internal/quote-body.ts
@@ -1,0 +1,78 @@
+/**
+ * Build HTML + text quote blocks for inclusion in a reply or forward.
+ *
+ * Internal module; re-exported publicly as `quoteBody` from
+ * `../composition.ts`.
+ *
+ * @module
+ */
+
+import type { ParsedEmail } from "../types.ts";
+
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function textToSimpleHtml(text: string): string {
+  return escapeHtml(text).replace(/\r?\n/g, "<br>");
+}
+
+function formatAttribution(
+  original: ParsedEmail,
+): string | undefined {
+  const who = original.from
+    ? original.from.name && original.from.name.length > 0
+      ? original.from.name
+      : original.from.address
+    : undefined;
+  const when = original.date ? original.date.toISOString() : undefined;
+
+  if (who && when) return `On ${when}, ${who} wrote:`;
+  if (who) return `${who} wrote:`;
+  if (when) return `On ${when}, someone wrote:`;
+
+  return undefined;
+}
+
+/**
+ * Format `original` as an HTML `<blockquote>` + a `> `-prefixed text
+ * quote, each preceded by an attribution line unless both `from` and
+ * `date` are missing.
+ *
+ * HTML quote uses `original.html` when present; otherwise falls back
+ * to `original.text` escaped and line-broken into simple HTML. Text
+ * quote always uses `original.text` (or `""` when absent).
+ */
+export function quoteBody(original: ParsedEmail): {
+  html: string;
+  text: string;
+} {
+  const attribution = formatAttribution(original);
+
+  const htmlSource = original.html
+    ? original.html
+    : original.text
+      ? textToSimpleHtml(original.text)
+      : "";
+  const htmlAttribution = attribution
+    ? `<p>${escapeHtml(attribution)}</p>\n`
+    : "";
+  const html = `${htmlAttribution}<blockquote>${htmlSource}</blockquote>`;
+
+  const textSource = original.text ?? "";
+  const quoted =
+    textSource.length > 0
+      ? textSource
+          .split(/\r?\n/)
+          .map((line) => `> ${line}`)
+          .join("\n")
+      : "> ";
+  const text = attribution ? `${attribution}\n${quoted}` : quoted;
+
+  return { html, text };
+}

--- a/src/internal/references-builder.test.ts
+++ b/src/internal/references-builder.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { buildReferences } from "./references-builder.ts";
+import type { ParsedEmail } from "../types.ts";
+
+function makeEmail(overrides: Partial<ParsedEmail> = {}): ParsedEmail {
+  return {
+    references: [],
+    to: [],
+    cc: [],
+    bcc: [],
+    attachments: [],
+    headers: new Map(),
+    ...overrides,
+  };
+}
+
+describe("buildReferences", () => {
+  it("returns [] when the original has no Message-ID and no References", () => {
+    expect(buildReferences(makeEmail())).toEqual([]);
+  });
+
+  it("returns just the Message-ID when References is empty", () => {
+    const email = makeEmail({ messageId: "<a@x>" });
+
+    expect(buildReferences(email)).toEqual(["<a@x>"]);
+  });
+
+  it("appends the Message-ID to the existing References", () => {
+    const email = makeEmail({
+      messageId: "<c@x>",
+      references: ["<a@x>", "<b@x>"],
+    });
+
+    expect(buildReferences(email)).toEqual(["<a@x>", "<b@x>", "<c@x>"]);
+  });
+
+  it("deduplicates while preserving first-seen order", () => {
+    const email = makeEmail({
+      messageId: "<b@x>",
+      references: ["<a@x>", "<b@x>", "<a@x>"],
+    });
+
+    expect(buildReferences(email)).toEqual(["<a@x>", "<b@x>"]);
+  });
+
+  it("keeps the full chain when it is exactly 20 entries", () => {
+    const ids = Array.from({ length: 20 }, (_, i) => `<id${i}@x>`);
+    const email = makeEmail({
+      references: ids.slice(0, 19),
+      messageId: ids[19],
+    });
+
+    expect(buildReferences(email)).toEqual(ids);
+  });
+
+  it("caps at 20 entries by keeping the first 3 and last 17", () => {
+    const ids = Array.from({ length: 25 }, (_, i) => `<id${i}@x>`);
+    const email = makeEmail({
+      references: ids.slice(0, 24),
+      messageId: ids[24],
+    });
+
+    const result = buildReferences(email);
+
+    expect(result).toHaveLength(20);
+    expect(result.slice(0, 3)).toEqual([
+      "<id0@x>",
+      "<id1@x>",
+      "<id2@x>",
+    ]);
+    expect(result.slice(3)).toEqual(ids.slice(25 - 17));
+  });
+
+  it("returns a fresh array — caller can mutate freely", () => {
+    const email = makeEmail({
+      messageId: "<a@x>",
+      references: [],
+    });
+    const result = buildReferences(email);
+
+    result.push("<extra@x>");
+
+    expect(email.references).toEqual([]);
+  });
+});

--- a/src/internal/references-builder.ts
+++ b/src/internal/references-builder.ts
@@ -1,0 +1,50 @@
+/**
+ * Build the `References:` header value for a reply or forward, with
+ * the 20-entry truncation rule (first 3 + last 17) that keeps long
+ * threads below every known SMTP-relay header-size cutoff.
+ *
+ * Internal module; re-exported publicly as `buildReferences` from
+ * `../composition.ts`.
+ *
+ * @module
+ */
+
+import type { ParsedEmail } from "../types.ts";
+
+const MAX_REFERENCES = 20;
+const KEEP_HEAD = 3;
+const KEEP_TAIL = MAX_REFERENCES - KEEP_HEAD;
+
+/**
+ * Concatenate `original.references` with `original.messageId` (if any),
+ * dedupe preserving order, then cap the result at 20 entries by
+ * keeping the first 3 and last 17. Caller receives a fresh array.
+ */
+export function buildReferences(original: ParsedEmail): string[] {
+  const combined: string[] = [...original.references];
+
+  if (original.messageId) {
+    combined.push(original.messageId);
+  }
+
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+
+  for (const ref of combined) {
+    if (seen.has(ref)) {
+      continue;
+    }
+
+    seen.add(ref);
+    deduped.push(ref);
+  }
+
+  if (deduped.length <= MAX_REFERENCES) {
+    return deduped;
+  }
+
+  return [
+    ...deduped.slice(0, KEEP_HEAD),
+    ...deduped.slice(deduped.length - KEEP_TAIL),
+  ];
+}

--- a/src/internal/subject-normalizer.ts
+++ b/src/internal/subject-normalizer.ts
@@ -43,6 +43,24 @@ const MAX_ITERATIONS = 10;
  * @param subject Raw subject. Non-string input returns `""`.
  * @returns Trimmed subject with every leading prefix removed.
  */
+/** True when `subject` already starts with a reply prefix. */
+export function hasReplyPrefix(subject: string): boolean {
+  if (typeof subject !== "string") {
+    return false;
+  }
+
+  return REPLY_PREFIX.test(subject.trim());
+}
+
+/** True when `subject` already starts with a forward prefix. */
+export function hasForwardPrefix(subject: string): boolean {
+  if (typeof subject !== "string") {
+    return false;
+  }
+
+  return FORWARD_PREFIX.test(subject.trim());
+}
+
 export function normalizeSubject(subject: string): string {
   if (typeof subject !== "string") {
     return "";

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,96 @@ export type ParsedEmail = {
 };
 
 /**
+ * A composed outbound message produced by {@link createReply},
+ * {@link createReplyAll}, {@link createForward}, or
+ * {@link createDraft}.
+ *
+ * `raw` contains the RFC 5322 serialized form and is ready to hand to
+ * any SMTP-capable transport. It intentionally **excludes** the `Bcc:`
+ * header — BCC recipients are exposed only through the structured
+ * `bcc` field so callers can drive envelope-level delivery without
+ * leaking the BCC list to other recipients.
+ */
+export type ComposedMessage = {
+  /** Freshly generated Message-ID including angle brackets. */
+  readonly messageId: string;
+  /** Set for replies; omitted for forwards and fresh drafts. */
+  readonly inReplyTo?: string | undefined;
+  /** Full `References` chain, truncated per {@link buildReferences}'s 20-entry cap. */
+  readonly references: readonly string[];
+  /** Subject as it will appear on the wire. */
+  readonly subject: string;
+  /** Sender. */
+  readonly from: EmailAddress;
+  /** Primary recipients. */
+  readonly to: readonly EmailAddress[];
+  /** Carbon-copy recipients. */
+  readonly cc: readonly EmailAddress[];
+  /** BCC recipients. **Never appear in `raw`** — use this field to drive envelope delivery. */
+  readonly bcc: readonly EmailAddress[];
+  /** HTML body, when present. */
+  readonly html?: string | undefined;
+  /** Plain-text body, when present. */
+  readonly text?: string | undefined;
+  /** Attachments copied into the outgoing MIME body. */
+  readonly attachments: readonly Attachment[];
+  /** RFC 5322 formatted string with CRLF line endings; excludes `Bcc:` — see {@link ComposedMessage.bcc}. */
+  readonly raw: string;
+};
+
+/**
+ * HTML and plain-text body parts for an outgoing message. At least
+ * one side should be populated for a sendable message; both-empty is
+ * accepted (mostly useful for "quote-only" replies).
+ */
+export type MessageBody = {
+  /** HTML body. */
+  readonly html?: string | undefined;
+  /** Plain-text body. */
+  readonly text?: string | undefined;
+};
+
+/** Options for {@link createReply} and {@link createReplyAll}. */
+export type ReplyOptions = {
+  /** Who the reply is from. */
+  readonly from: EmailAddress;
+  /** User-authored body that will sit above the quoted original. */
+  readonly body: MessageBody;
+  /** Addresses to strip from every recipient list (e.g. your own). */
+  readonly excludeAddresses?: readonly string[] | undefined;
+};
+
+/** Options for {@link createForward}. */
+export type ForwardOptions = {
+  /** Who the forward is from. */
+  readonly from: EmailAddress;
+  /** Primary recipients. */
+  readonly to: readonly EmailAddress[];
+  /** Optional carbon-copy recipients. */
+  readonly cc?: readonly EmailAddress[] | undefined;
+  /** Optional user note to insert above the forwarded block. */
+  readonly body?: MessageBody | undefined;
+};
+
+/** Options for {@link createDraft} — a brand-new, non-threaded message. */
+export type DraftOptions = {
+  /** Who the draft is from. */
+  readonly from: EmailAddress;
+  /** Primary recipients. Defaults to empty. */
+  readonly to?: readonly EmailAddress[] | undefined;
+  /** Carbon-copy recipients. Defaults to empty. */
+  readonly cc?: readonly EmailAddress[] | undefined;
+  /** Blind carbon-copy recipients. Never serialized into `raw`. */
+  readonly bcc?: readonly EmailAddress[] | undefined;
+  /** Subject. Defaults to empty. */
+  readonly subject?: string | undefined;
+  /** User-authored body. */
+  readonly body?: MessageBody | undefined;
+  /** Attachments. Each must carry `content` at serialization time. */
+  readonly attachments?: readonly Attachment[] | undefined;
+};
+
+/**
  * The subset of {@link ParsedEmail} fields needed to determine thread
  * membership. Extract via {@link extractThreadingHeaders} when you only
  * need to make threading decisions without holding the full record.


### PR DESCRIPTION
The last big module of the library — reply, reply-all, forward, and draft composition, plus the three helpers that make them work (`generateMessageId`, `buildReferences`, `quoteBody`).

The headline invariant: `ComposedMessage.raw` never contains a `Bcc:` header, ever. Callers who need BCC delivery use the structured `bcc` field for per-recipient envelope routing. That invariant is asserted in tests for every composition function.

`createForward` (and now `createDraft`) fail loudly when any attachment is missing its `content` — silently dropping a file would be worse than a thrown error. Replies correctly skip `In-Reply-To` when the original's Message-ID is one of our synthesized orphan ids. `createReplyAll` dedupes across `To` and `Cc` case-insensitively.

Multi-language subject handling now flows all the way through: an `Aw:` / `Rép:` / `Sv:` reply doesn't get a double `Re:` prefix, and `Wg:` / `Tr:` / `Vs:` forwards don't get a double `Fwd:`.

Round-tripping a composed message back through `parseMessage` recovers the same `to`, `from`, `subject`, `messageId`, `references`, `inReplyTo`, body, and attachments — so what we emit is actually valid RFC 5322.

252 tests green (77 new). JSR dry-run clean, no slow types.

Closes #3