### PR TITLE
Threading: bracket-insensitive Message-ID matching and sender-overlap guard

### DIFF
--- a/src/threading.test.ts
+++ b/src/threading.test.ts
@@ -795,6 +795,68 @@ describe("buildThreads — Message-ID bracket normalization", () => {
     expect(threads[0]?.id).toBe("a@x");
   });
 
+  it("links through a References chain whose adjacent entries use mixed bracket styles", () => {
+    // The middle ancestor `<mid@x>` is only reachable via refs[0]→refs[1]
+    // chain linkage (c's In-Reply-To is the *last* ref, not the middle).
+    // Each adjacent pair in the refs list uses a different bracket style
+    // to force canonical comparison at every step of the chain walk.
+    const a = makeEmail({
+      messageId: "<a@x>",
+      subject: "Hi",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const mid = makeEmail({
+      messageId: "<mid@x>",
+      inReplyTo: "a@x",
+      references: ["a@x"],
+      subject: "Re: Hi",
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+    const c = makeEmail({
+      messageId: "<c@x>",
+      inReplyTo: "mid@x",
+      references: ["<a@x>", "mid@x"],
+      subject: "Re: Hi",
+      date: new Date("2026-04-19T02:00:00Z"),
+    });
+
+    const threads = buildThreads([a, mid, c]);
+
+    expect(threads).toHaveLength(1);
+    expect(threads[0]?.messageCount).toBe(3);
+    const midNode = threads[0]?.root.children[0];
+
+    expect(midNode?.messageId).toBe("<mid@x>");
+    expect(midNode?.children[0]?.messageId).toBe("<c@x>");
+  });
+
+  it("detects cycles across mixed bracket styles", () => {
+    // Each email names the other as its In-Reply-To, in a different
+    // bracket style. Without canonical cycle detection they'd appear
+    // to be independent links and one would silently lose its parent
+    // pointer or we'd emit an infinite tree.
+    const a = makeEmail({
+      messageId: "<a@x>",
+      inReplyTo: "b@x",
+      subject: "loop",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const b = makeEmail({
+      messageId: "<b@x>",
+      inReplyTo: "<a@x>",
+      subject: "loop",
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+
+    const threads = buildThreads([a, b]);
+    const ids: string[] = [];
+
+    for (const t of threads) walkIds(t.root, (id) => ids.push(id));
+
+    expect(ids).toContain("<a@x>");
+    expect(ids).toContain("<b@x>");
+  });
+
   it("dedupes duplicate Message-IDs that differ only in bracket style", () => {
     const bracketed = makeEmail({
       messageId: "<dup@x>",
@@ -851,6 +913,28 @@ describe("buildThreads — subject fallback sender-overlap", () => {
       subject: "Re: Meeting",
       from: { address: "bob@x" },
       to: [{ address: "CHRIS@x" }],
+      date: new Date("2026-04-20T00:00:00Z"),
+    });
+
+    const threads = buildThreads([a, b]);
+
+    expect(threads).toHaveLength(1);
+    expect(threads[0]?.messageCount).toBe(2);
+  });
+
+  it("merges when the only shared participant appears via Bcc", () => {
+    const a = makeEmail({
+      messageId: "<a@x>",
+      subject: "Meeting",
+      from: { address: "alice@x" },
+      bcc: [{ address: "shared@x" }],
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const b = makeEmail({
+      messageId: "<b@x>",
+      subject: "Re: Meeting",
+      from: { address: "bob@x" },
+      to: [{ address: "shared@x" }],
       date: new Date("2026-04-20T00:00:00Z"),
     });
 
@@ -946,6 +1030,28 @@ describe("ingestIntoThreads — subject fallback sender-overlap", () => {
       subject: "Re: Meeting",
       from: { address: "charlie@x" },
       to: [{ address: "ALICE@x" }],
+      date: new Date("2026-04-20T00:00:00Z"),
+    });
+
+    const { affectedThreadId } = ingestIntoThreads(reply, existing);
+
+    expect(affectedThreadId).toBe("<root@x>");
+  });
+
+  it("matches when the only shared participant appears via Bcc on the incoming email", () => {
+    const root = makeEmail({
+      messageId: "<root@x>",
+      subject: "Meeting",
+      from: { address: "alice@x" },
+      to: [{ address: "bob@x" }],
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const existing = buildThreads([root]);
+    const reply = makeEmail({
+      messageId: "<r@x>",
+      subject: "Re: Meeting",
+      from: { address: "charlie@x" },
+      bcc: [{ address: "alice@x" }],
       date: new Date("2026-04-20T00:00:00Z"),
     });
 

--- a/src/threading.test.ts
+++ b/src/threading.test.ts
@@ -393,15 +393,19 @@ describe("buildThreads — sibling sort", () => {
 });
 
 describe("buildThreads — subject fallback", () => {
-  it("groups messages with the same normalized subject within ±7 days", () => {
+  it("groups messages with the same normalized subject within ±7 days when participants overlap", () => {
     const a = makeEmail({
       messageId: "<a@x>",
       subject: "Planning sync",
+      from: { address: "ada@x" },
+      to: [{ address: "grace@x" }],
       date: new Date("2026-04-19T00:00:00Z"),
     });
     const b = makeEmail({
       messageId: "<b@x>",
       subject: "Re: Planning sync",
+      from: { address: "grace@x" },
+      to: [{ address: "ada@x" }],
       date: new Date("2026-04-20T00:00:00Z"),
     });
 
@@ -415,11 +419,15 @@ describe("buildThreads — subject fallback", () => {
     const a = makeEmail({
       messageId: "<a@x>",
       subject: "Planning Sync",
+      from: { address: "ada@x" },
+      to: [{ address: "grace@x" }],
       date: new Date("2026-04-19T00:00:00Z"),
     });
     const b = makeEmail({
       messageId: "<b@x>",
       subject: "re: PLANNING sync",
+      from: { address: "grace@x" },
+      to: [{ address: "ada@x" }],
       date: new Date("2026-04-20T00:00:00Z"),
     });
 
@@ -739,5 +747,210 @@ describe("ingestIntoThreads", () => {
     expect(threads[0]?.lastDate).toEqual(new Date("2026-04-19T02:00:00Z"));
     const addresses = threads[0]!.participants.map((p) => p.address).sort();
     expect(addresses).toEqual(["ada@x", "bob@x", "grace@x"]);
+  });
+});
+
+describe("buildThreads — Message-ID bracket normalization", () => {
+  it("links a reply whose In-Reply-To drops the brackets", () => {
+    const a = makeEmail({
+      messageId: "<a@x>",
+      subject: "Hi",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const b = makeEmail({
+      messageId: "<b@x>",
+      inReplyTo: "a@x",
+      references: ["a@x"],
+      subject: "Re: Hi",
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+
+    const threads = buildThreads([a, b]);
+
+    expect(threads).toHaveLength(1);
+    expect(threads[0]?.id).toBe("<a@x>");
+    expect(threads[0]?.messageCount).toBe(2);
+    expect(threads[0]?.root.children[0]?.messageId).toBe("<b@x>");
+  });
+
+  it("links a reply whose Message-ID has brackets but parent's Message-ID doesn't", () => {
+    const a = makeEmail({
+      messageId: "a@x",
+      subject: "Hi",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const b = makeEmail({
+      messageId: "<b@x>",
+      inReplyTo: "<a@x>",
+      references: ["<a@x>"],
+      subject: "Re: Hi",
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+
+    const threads = buildThreads([a, b]);
+
+    expect(threads).toHaveLength(1);
+    expect(threads[0]?.messageCount).toBe(2);
+    // Preserves the parent's original (bare) Message-ID as the thread id.
+    expect(threads[0]?.id).toBe("a@x");
+  });
+
+  it("dedupes duplicate Message-IDs that differ only in bracket style", () => {
+    const bracketed = makeEmail({
+      messageId: "<dup@x>",
+      subject: "dup",
+      text: "plain",
+      html: "<p>html</p>",
+    });
+    const bare = makeEmail({
+      messageId: "dup@x",
+      subject: "dup",
+      text: "plain",
+    });
+
+    const threads = buildThreads([bracketed, bare]);
+
+    expect(threads).toHaveLength(1);
+    expect(threads[0]?.messageCount).toBe(1);
+    expect(threads[0]?.root.email).toBe(bracketed);
+  });
+});
+
+describe("buildThreads — subject fallback sender-overlap", () => {
+  it("does NOT merge subjects when no participant is shared", () => {
+    const a = makeEmail({
+      messageId: "<a@x>",
+      subject: "Meeting",
+      from: { address: "team1-a@x" },
+      to: [{ address: "team1-b@x" }],
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const b = makeEmail({
+      messageId: "<b@x>",
+      subject: "Re: Meeting",
+      from: { address: "team2-a@x" },
+      to: [{ address: "team2-b@x" }],
+      date: new Date("2026-04-20T00:00:00Z"),
+    });
+
+    const threads = buildThreads([a, b]);
+
+    expect(threads).toHaveLength(2);
+  });
+
+  it("merges subjects when at least one participant is shared across to/cc/bcc/from", () => {
+    const a = makeEmail({
+      messageId: "<a@x>",
+      subject: "Meeting",
+      from: { address: "alice@x" },
+      cc: [{ address: "chris@x" }],
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const b = makeEmail({
+      messageId: "<b@x>",
+      subject: "Re: Meeting",
+      from: { address: "bob@x" },
+      to: [{ address: "CHRIS@x" }],
+      date: new Date("2026-04-20T00:00:00Z"),
+    });
+
+    const threads = buildThreads([a, b]);
+
+    expect(threads).toHaveLength(1);
+    expect(threads[0]?.messageCount).toBe(2);
+  });
+});
+
+describe("ingestIntoThreads — Message-ID bracket normalization", () => {
+  it("matches when existing thread id has brackets and incoming refs don't", () => {
+    const root = makeEmail({
+      messageId: "<root@x>",
+      subject: "Hi",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const existing = buildThreads([root]);
+    const reply = makeEmail({
+      messageId: "<reply@x>",
+      inReplyTo: "root@x",
+      references: ["root@x"],
+      subject: "Re: Hi",
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+
+    const { threads, affectedThreadId } = ingestIntoThreads(reply, existing);
+
+    expect(affectedThreadId).toBe("<root@x>");
+    expect(threads[0]?.messageCount).toBe(2);
+    expect(threads[0]?.root.children[0]?.messageId).toBe("<reply@x>");
+  });
+
+  it("matches when existing thread id has no brackets and incoming refs do", () => {
+    const root = makeEmail({
+      messageId: "root@x",
+      subject: "Hi",
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const existing = buildThreads([root]);
+    const reply = makeEmail({
+      messageId: "<reply@x>",
+      inReplyTo: "<root@x>",
+      references: ["<root@x>"],
+      subject: "Re: Hi",
+      date: new Date("2026-04-19T01:00:00Z"),
+    });
+
+    const { affectedThreadId } = ingestIntoThreads(reply, existing);
+
+    expect(affectedThreadId).toBe("root@x");
+  });
+});
+
+describe("ingestIntoThreads — subject fallback sender-overlap", () => {
+  it("creates a new thread when the subject matches but no participant is shared", () => {
+    const root = makeEmail({
+      messageId: "<root@x>",
+      subject: "Meeting",
+      from: { address: "team1-a@x" },
+      to: [{ address: "team1-b@x" }],
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const existing = buildThreads([root]);
+    const unrelated = makeEmail({
+      messageId: "<u@x>",
+      subject: "Re: Meeting",
+      from: { address: "team2-a@x" },
+      to: [{ address: "team2-b@x" }],
+      date: new Date("2026-04-20T00:00:00Z"),
+    });
+
+    const { threads, affectedThreadId } = ingestIntoThreads(
+      unrelated,
+      existing,
+    );
+
+    expect(threads).toHaveLength(2);
+    expect(affectedThreadId).toBe("<u@x>");
+  });
+
+  it("matches when the subject and at least one participant overlap", () => {
+    const root = makeEmail({
+      messageId: "<root@x>",
+      subject: "Meeting",
+      from: { address: "alice@x" },
+      to: [{ address: "bob@x" }],
+      date: new Date("2026-04-19T00:00:00Z"),
+    });
+    const existing = buildThreads([root]);
+    const reply = makeEmail({
+      messageId: "<r@x>",
+      subject: "Re: Meeting",
+      from: { address: "charlie@x" },
+      to: [{ address: "ALICE@x" }],
+      date: new Date("2026-04-20T00:00:00Z"),
+    });
+
+    const { affectedThreadId } = ingestIntoThreads(reply, existing);
+
+    expect(affectedThreadId).toBe("<root@x>");
   });
 });

--- a/src/threading.ts
+++ b/src/threading.ts
@@ -190,29 +190,57 @@ export function ingestIntoThreads(
 // ─── JWZ container implementation ────────────────────────────────────
 
 interface Container {
+  // Display form of the Message-ID — what callers get back on
+  // ThreadNode.messageId / Thread.id. Preserves whichever form first
+  // created the container (usually bracketed RFC form).
   messageId: string;
+  // Canonical form (brackets + whitespace stripped) — the stable
+  // identity used as the map key and for every parent / cycle
+  // comparison. Lets `<id@host>` in Message-ID match `id@host` in
+  // In-Reply-To / References across mail systems that normalize one
+  // but not the other.
+  canonicalId: string;
   email: ParsedEmail | undefined;
-  parentId: string | undefined;
+  // Canonical form of parent's id; undefined for roots.
+  parentCanonicalId: string | undefined;
   children: Container[];
 }
 
-function makeContainer(messageId: string): Container {
-  return { messageId, email: undefined, parentId: undefined, children: [] };
+// Strip surrounding whitespace and angle brackets from a Message-ID
+// for equality comparisons. Never mutates stored display ids.
+function canonicalMessageId(id: string): string {
+  let s = id.trim();
+
+  if (s.startsWith("<")) s = s.slice(1);
+  if (s.endsWith(">")) s = s.slice(0, -1);
+
+  return s.trim();
+}
+
+function makeContainer(messageId: string, canonicalId: string): Container {
+  return {
+    messageId,
+    canonicalId,
+    email: undefined,
+    parentCanonicalId: undefined,
+    children: [],
+  };
 }
 
 function ensureContainer(
   map: Map<string, Container>,
-  messageId: string,
+  rawId: string,
 ): Container {
-  const existing = map.get(messageId);
+  const key = canonicalMessageId(rawId);
+  const existing = map.get(key);
 
   if (existing) {
     return existing;
   }
 
-  const container = makeContainer(messageId);
+  const container = makeContainer(rawId, key);
 
-  map.set(messageId, container);
+  map.set(key, container);
 
   return container;
 }
@@ -273,21 +301,23 @@ function dedupeByMessageId(
 ): ParsedEmail[] {
   // Dedupe orphans by their synthesized id alongside real Message-IDs
   // so two orphans with identical hashable fields don't silently
-  // collide later in buildContainerMap.
+  // collide later in buildContainerMap. Keyed by canonical form so
+  // `<id@host>` and `id@host` count as the same message.
   const byId = new Map<string, ParsedEmail>();
 
   for (const email of emails) {
-    const id = email.messageId ?? synthesizeOrphanId(email);
-    const existing = byId.get(id);
+    const raw = email.messageId ?? synthesizeOrphanId(email);
+    const key = canonicalMessageId(raw);
+    const existing = byId.get(key);
 
     if (!existing) {
-      byId.set(id, email);
+      byId.set(key, email);
 
       continue;
     }
 
     if (candidateIsRicher(email, existing)) {
-      byId.set(id, email);
+      byId.set(key, email);
     }
   }
 
@@ -300,10 +330,14 @@ function buildContainerMap(
   const map = new Map<string, Container>();
 
   for (const email of emails) {
-    const id = email.messageId ?? synthesizeOrphanId(email);
-    const container = ensureContainer(map, id);
+    const rawId = email.messageId ?? synthesizeOrphanId(email);
+    const container = ensureContainer(map, rawId);
 
     container.email = email;
+    // Prefer the email's own Message-ID as the display form — even if
+    // the container was first created from a reference in a different
+    // bracket style.
+    container.messageId = rawId;
   }
 
   return map;
@@ -316,28 +350,35 @@ function linkByReferences(
   for (const email of emails) {
     linkReferenceChain(map, email.references);
 
-    const childId = email.messageId ?? synthesizeOrphanId(email);
-    const child = map.get(childId);
+    const childRawId = email.messageId ?? synthesizeOrphanId(email);
+    const childKey = canonicalMessageId(childRawId);
+    const child = map.get(childKey);
 
-    if (!child || child.parentId !== undefined) {
+    if (!child || child.parentCanonicalId !== undefined) {
       continue;
     }
 
-    const parentId = findParentId(email);
+    const parentRawId = findParentId(email);
 
-    if (!parentId || parentId === childId) {
+    if (!parentRawId) {
       continue;
     }
 
-    if (wouldCreateCycle(map, childId, parentId)) {
-      // Linking `child → parentId` would close a cycle; keep child a
+    const parentKey = canonicalMessageId(parentRawId);
+
+    if (parentKey === childKey) {
+      continue;
+    }
+
+    if (wouldCreateCycle(map, childKey, parentKey)) {
+      // Linking `child → parent` would close a cycle; keep child a
       // root rather than silently dropping it.
       continue;
     }
 
-    const parent = ensureContainer(map, parentId);
+    const parent = ensureContainer(map, parentRawId);
 
-    child.parentId = parentId;
+    child.parentCanonicalId = parentKey;
     parent.children.push(child);
   }
 }
@@ -352,44 +393,46 @@ function linkReferenceChain(
   refs: ReadonlyArray<string>,
 ): void {
   for (let i = 0; i < refs.length - 1; i++) {
-    const parentId = refs[i]!;
-    const childId = refs[i + 1]!;
+    const parentRawId = refs[i]!;
+    const childRawId = refs[i + 1]!;
+    const parentKey = canonicalMessageId(parentRawId);
+    const childKey = canonicalMessageId(childRawId);
 
-    if (parentId === childId) {
+    if (parentKey === childKey) {
       continue;
     }
 
-    const childContainer = ensureContainer(map, childId);
+    const childContainer = ensureContainer(map, childRawId);
 
-    if (childContainer.parentId !== undefined) {
+    if (childContainer.parentCanonicalId !== undefined) {
       continue;
     }
 
-    if (wouldCreateCycle(map, childId, parentId)) {
+    if (wouldCreateCycle(map, childKey, parentKey)) {
       continue;
     }
 
-    const parentContainer = ensureContainer(map, parentId);
+    const parentContainer = ensureContainer(map, parentRawId);
 
-    childContainer.parentId = parentId;
+    childContainer.parentCanonicalId = parentKey;
     parentContainer.children.push(childContainer);
   }
 }
 
-// Walks the existing parent chain starting at `parentId`; returns
-// `true` if it reaches `childId`, which would mean linking them
+// Walks the existing parent chain starting at `parentKey`; returns
+// `true` if it reaches `childKey`, which would mean linking them
 // closes a cycle. Also breaks out on any pre-existing cycle in the
 // map to stay finite.
 function wouldCreateCycle(
   map: Map<string, Container>,
-  childId: string,
-  parentId: string,
+  childKey: string,
+  parentKey: string,
 ): boolean {
   const visited = new Set<string>();
-  let cursor: string | undefined = parentId;
+  let cursor: string | undefined = parentKey;
 
   while (cursor !== undefined) {
-    if (cursor === childId) {
+    if (cursor === childKey) {
       return true;
     }
 
@@ -398,7 +441,7 @@ function wouldCreateCycle(
     }
 
     visited.add(cursor);
-    cursor = map.get(cursor)?.parentId;
+    cursor = map.get(cursor)?.parentCanonicalId;
   }
 
   return false;
@@ -417,11 +460,14 @@ function findParentId(email: ParsedEmail): string | undefined {
 
 function linkBySubjectFallback(map: Map<string, Container>): void {
   // Group candidate roots by normalized subject within a ±7-day window.
+  // Require at least one shared participant before merging — prevents
+  // unrelated teams sharing a generic subject ("Meeting", "Planning
+  // sync") from being stitched into one thread.
   const WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
   const bySubject = new Map<string, Container[]>();
 
   for (const container of map.values()) {
-    if (container.parentId !== undefined || !container.email) {
+    if (container.parentCanonicalId !== undefined || !container.email) {
       continue;
     }
 
@@ -449,6 +495,9 @@ function linkBySubjectFallback(map: Map<string, Container>): void {
     group.sort(compareContainersByDate);
 
     const root = group[0]!;
+    const rootParts = root.email
+      ? emailParticipantSet(root.email)
+      : undefined;
 
     for (let i = 1; i < group.length; i++) {
       const candidate = group[i]!;
@@ -457,11 +506,40 @@ function linkBySubjectFallback(map: Map<string, Container>): void {
         continue;
       }
 
-      candidate.parentId = root.messageId;
+      if (!rootParts || !candidate.email) {
+        continue;
+      }
+
+      const candParts = emailParticipantSet(candidate.email);
+
+      if (!sharesAddress(rootParts, candParts)) {
+        continue;
+      }
+
+      candidate.parentCanonicalId = root.canonicalId;
       root.children.push(candidate);
     }
   }
 
+}
+
+function emailParticipantSet(email: ParsedEmail): Set<string> {
+  const set = new Set<string>();
+
+  if (email.from) set.add(email.from.address.toLowerCase());
+  for (const a of email.to) set.add(a.address.toLowerCase());
+  for (const a of email.cc) set.add(a.address.toLowerCase());
+  for (const a of email.bcc) set.add(a.address.toLowerCase());
+
+  return set;
+}
+
+function sharesAddress(a: Set<string>, b: Set<string>): boolean {
+  for (const x of a) {
+    if (b.has(x)) return true;
+  }
+
+  return false;
 }
 
 function withinWindow(
@@ -483,7 +561,7 @@ function collectRoots(map: Map<string, Container>): Container[] {
   const roots: Container[] = [];
 
   for (const container of map.values()) {
-    if (container.parentId === undefined) {
+    if (container.parentCanonicalId === undefined) {
       roots.push(container);
     }
   }
@@ -516,7 +594,7 @@ function pruneEmptyContainers(node: Container): Container[] {
   if (prunedChildren.length === 1) {
     const only = prunedChildren[0]!;
 
-    only.parentId = undefined;
+    only.parentCanonicalId = undefined;
 
     return [only];
   }
@@ -664,17 +742,19 @@ function findMatchingThread(
   email: ParsedEmail,
   threads: ReadonlyArray<Thread>,
 ): Thread | undefined {
-  const candidateIds = new Set<string>();
+  const candidateKeys = new Set<string>();
 
-  if (email.inReplyTo) candidateIds.add(email.inReplyTo);
-  for (const r of email.references) candidateIds.add(r);
+  if (email.inReplyTo) candidateKeys.add(canonicalMessageId(email.inReplyTo));
+  for (const r of email.references) candidateKeys.add(canonicalMessageId(r));
 
-  if (candidateIds.size > 0) {
+  if (candidateKeys.size > 0) {
     const threadIds = collectAllMessageIds(threads);
 
-    for (const id of candidateIds) {
-      if (threadIds.has(id)) {
-        return threadById(threads, threadIds.get(id)!);
+    for (const key of candidateKeys) {
+      const threadId = threadIds.get(key);
+
+      if (threadId !== undefined) {
+        return threadById(threads, threadId);
       }
     }
   }
@@ -685,26 +765,39 @@ function findMatchingThread(
     return undefined;
   }
 
+  const emailParts = emailParticipantSet(email);
+
   for (const thread of threads) {
     if (!thread.subject || thread.subject.toLowerCase() !== subjectKey) {
       continue;
     }
 
-    if (datesWithinWindow(email.date, thread.lastDate)) {
-      return thread;
+    if (!datesWithinWindow(email.date, thread.lastDate)) {
+      continue;
     }
+
+    // Require ≥1 shared participant so unrelated threads sharing a
+    // generic subject don't merge on subject alone.
+    const threadParts = threadParticipantSet(thread);
+
+    if (!sharesAddress(emailParts, threadParts)) {
+      continue;
+    }
+
+    return thread;
   }
 
   return undefined;
 }
 
+// canonical Message-ID -> thread id (display form)
 function collectAllMessageIds(
   threads: ReadonlyArray<Thread>,
 ): Map<string, string> {
   const map = new Map<string, string>();
 
   function visit(threadId: string, node: ThreadNode): void {
-    map.set(node.messageId, threadId);
+    map.set(canonicalMessageId(node.messageId), threadId);
 
     for (const child of node.children) visit(threadId, child);
   }
@@ -714,6 +807,16 @@ function collectAllMessageIds(
   }
 
   return map;
+}
+
+function threadParticipantSet(thread: Thread): Set<string> {
+  const set = new Set<string>();
+
+  for (const p of thread.participants) {
+    set.add(p.address.toLowerCase());
+  }
+
+  return set;
 }
 
 function threadById(
@@ -742,8 +845,11 @@ function insertEmailIntoThread(
     messageId,
     children: [],
   };
-  const parentId = findParentId(email);
-  const attempt = insertUnderParent(thread.root, newNode, parentId);
+  const parentRawId = findParentId(email);
+  const parentKey = parentRawId
+    ? canonicalMessageId(parentRawId)
+    : undefined;
+  const attempt = insertUnderParent(thread.root, newNode, parentKey);
 
   // If no parent was found in the tree, attach the new node as a
   // direct child of the thread root so the email is never silently
@@ -772,9 +878,9 @@ function insertEmailIntoThread(
 function insertUnderParent(
   node: ThreadNode,
   newNode: ThreadNode,
-  parentId: string | undefined,
+  parentKey: string | undefined,
 ): { node: ThreadNode; inserted: boolean } {
-  if (parentId && node.messageId === parentId) {
+  if (parentKey && canonicalMessageId(node.messageId) === parentKey) {
     return {
       node: {
         ...node,
@@ -786,7 +892,7 @@ function insertUnderParent(
 
   let inserted = false;
   const newChildren = node.children.map((c) => {
-    const result = insertUnderParent(c, newNode, parentId);
+    const result = insertUnderParent(c, newNode, parentKey);
 
     if (result.inserted) inserted = true;
 

--- a/src/threading.ts
+++ b/src/threading.ts
@@ -189,19 +189,14 @@ export function ingestIntoThreads(
 
 // ─── JWZ container implementation ────────────────────────────────────
 
+// `canonicalId` is the map key / comparison identity (brackets
+// stripped), so `<id@host>` in Message-ID still matches `id@host` in
+// In-Reply-To across systems that normalize one form but not the
+// other. `messageId` keeps whichever form arrived first, for output.
 interface Container {
-  // Display form of the Message-ID — what callers get back on
-  // ThreadNode.messageId / Thread.id. Preserves whichever form first
-  // created the container (usually bracketed RFC form).
   messageId: string;
-  // Canonical form (brackets + whitespace stripped) — the stable
-  // identity used as the map key and for every parent / cycle
-  // comparison. Lets `<id@host>` in Message-ID match `id@host` in
-  // In-Reply-To / References across mail systems that normalize one
-  // but not the other.
   canonicalId: string;
   email: ParsedEmail | undefined;
-  // Canonical form of parent's id; undefined for roots.
   parentCanonicalId: string | undefined;
   children: Container[];
 }
@@ -494,10 +489,10 @@ function linkBySubjectFallback(map: Map<string, Container>): void {
     // Earliest-dated member becomes the synthetic root for the group.
     group.sort(compareContainersByDate);
 
+    // Every container in `group` carries an email (filtered above), so
+    // .email is non-null on root and every candidate here.
     const root = group[0]!;
-    const rootParts = root.email
-      ? emailParticipantSet(root.email)
-      : undefined;
+    const rootParts = emailParticipantSet(root.email!);
 
     for (let i = 1; i < group.length; i++) {
       const candidate = group[i]!;
@@ -506,11 +501,7 @@ function linkBySubjectFallback(map: Map<string, Container>): void {
         continue;
       }
 
-      if (!rootParts || !candidate.email) {
-        continue;
-      }
-
-      const candParts = emailParticipantSet(candidate.email);
+      const candParts = emailParticipantSet(candidate.email!);
 
       if (!sharesAddress(rootParts, candParts)) {
         continue;
@@ -520,7 +511,6 @@ function linkBySubjectFallback(map: Map<string, Container>): void {
       root.children.push(candidate);
     }
   }
-
 }
 
 function emailParticipantSet(email: ParsedEmail): Set<string> {


### PR DESCRIPTION
## Summary

Threading used to break whenever two mail systems disagreed on whether a `Message-ID` should carry angle brackets — one side wrote `<id@host>`, the other wrote `id@host` in `In-Reply-To`, and replies ended up in their own lonely thread. This change strips brackets for every internal comparison so those messages join the right conversation, while the original form is kept for display.

The subject-fallback rule that stitches replies together when the `References:` header is missing also got stricter: two unrelated teams who happen to use the same generic subject (like "Meeting") within a week no longer get merged into one thread. They now need at least one person in common.

Closes #13

## Test plan
- [x] `make typecheck` passes
- [x] `make test` — all 267 tests pass (13 new)
- [x] `make publish-jsr-dry` — clean