### PR TITLE
Opt-in parse caps and an orphaned-cid helper

### DIFF
--- a/src/content.test.ts
+++ b/src/content.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   extractBody,
+  findOrphanedCidRefs,
   isInlineAttachment,
   listAttachments,
 } from "./content.ts";
@@ -163,5 +164,67 @@ describe("listAttachments", () => {
     ];
 
     expect(listAttachments(makeEmail({ attachments }))).toEqual([]);
+  });
+});
+
+describe("findOrphanedCidRefs", () => {
+  it("returns [] when the email has no html body", () => {
+    expect(findOrphanedCidRefs(makeEmail({ text: "plain" }))).toEqual([]);
+  });
+
+  it("returns [] when every cid reference is backed by an inline attachment", () => {
+    const html = `<p>top</p><img src="cid:logo@x"><img src="cid:sig@x">`;
+    const attachments: Attachment[] = [
+      makeAttachment({ disposition: "inline", contentId: "<logo@x>" }),
+      makeAttachment({ disposition: "inline", contentId: "<sig@x>" }),
+    ];
+
+    expect(findOrphanedCidRefs(makeEmail({ html, attachments }))).toEqual([]);
+  });
+
+  it("returns orphaned cid tokens in first-seen order, deduplicated", () => {
+    const html = `<img src="cid:logo@x"><img src="cid:missing@x"><img src="cid:missing@x">`;
+    const attachments: Attachment[] = [
+      makeAttachment({ disposition: "inline", contentId: "<logo@x>" }),
+    ];
+
+    expect(findOrphanedCidRefs(makeEmail({ html, attachments }))).toEqual([
+      "missing@x",
+    ]);
+  });
+
+  it("matches cid tokens whether the inline attachment's contentId has brackets or not", () => {
+    const html = `<img src="cid:a@x"><img src="cid:b@x">`;
+    const attachments: Attachment[] = [
+      makeAttachment({ disposition: "inline", contentId: "<a@x>" }),
+      makeAttachment({ disposition: "inline", contentId: "b@x" }),
+    ];
+
+    expect(findOrphanedCidRefs(makeEmail({ html, attachments }))).toEqual([]);
+  });
+
+  it("treats non-inline attachments as non-backing even when they share a contentId", () => {
+    const html = `<img src="cid:payload@x">`;
+    const attachments: Attachment[] = [
+      makeAttachment({ disposition: "attachment", contentId: "<payload@x>" }),
+    ];
+
+    expect(findOrphanedCidRefs(makeEmail({ html, attachments }))).toEqual([
+      "payload@x",
+    ]);
+  });
+
+  it("extracts cid tokens from multiple quote styles and attribute contexts", () => {
+    const html = `
+      <img src="cid:one@x">
+      <img src='cid:two@x'>
+      <a href="cid:three@x">x</a>
+    `;
+
+    expect(findOrphanedCidRefs(makeEmail({ html }))).toEqual([
+      "one@x",
+      "two@x",
+      "three@x",
+    ]);
   });
 });

--- a/src/content.test.ts
+++ b/src/content.test.ts
@@ -227,4 +227,53 @@ describe("findOrphanedCidRefs", () => {
       "three@x",
     ]);
   });
+
+  it("preserves first-seen order across multiple distinct orphans", () => {
+    const html = `
+      <img src="cid:b@x">
+      <img src="cid:a@x">
+      <img src="cid:c@x">
+      <img src="cid:a@x">
+    `;
+
+    expect(findOrphanedCidRefs(makeEmail({ html }))).toEqual([
+      "b@x",
+      "a@x",
+      "c@x",
+    ]);
+  });
+
+  it("strips common trailing punctuation from the extracted token", () => {
+    // Real emails embed cid refs in css and inline scripts, where
+    // `;` or `,` are the natural terminators — they shouldn't become
+    // part of the token.
+    const html = `<style>.a{background:url(cid:foo@x);}</style>`;
+    const attachments: Attachment[] = [
+      makeAttachment({ disposition: "inline", contentId: "<foo@x>" }),
+    ];
+
+    expect(findOrphanedCidRefs(makeEmail({ html, attachments }))).toEqual([]);
+  });
+
+  it("ignores http URLs that contain `cid:` inside the path", () => {
+    // Without the preceding-slash guard, `http://example.com/cid:foo`
+    // would be misreported as an orphan ref.
+    const html = `<a href="http://example.com/cid:not-really@x">x</a>`;
+
+    expect(findOrphanedCidRefs(makeEmail({ html }))).toEqual([]);
+  });
+
+  it("treats cid tokens as case-sensitive (RFC 2392 unique-id portion)", () => {
+    // `cid:` scheme is case-insensitive; the unique-id portion is
+    // case-sensitive per RFC 2392. A mismatched case should surface
+    // as an orphan rather than silently matching.
+    const html = `<img src="CID:Logo@X">`;
+    const attachments: Attachment[] = [
+      makeAttachment({ disposition: "inline", contentId: "<logo@x>" }),
+    ];
+
+    expect(findOrphanedCidRefs(makeEmail({ html, attachments }))).toEqual([
+      "Logo@X",
+    ]);
+  });
 });

--- a/src/content.ts
+++ b/src/content.ts
@@ -139,7 +139,11 @@ export function findOrphanedCidRefs(email: ParsedEmail): string[] {
 
   const orphans: string[] = [];
   const seen = new Set<string>();
-  const pattern = /cid:([^\s"'>)]+)/gi;
+
+  // Require cid: to not follow a letter/digit/slash so `http://host/cid:foo`
+  // doesn't match. Token chars exclude common terminators so
+  // `url(cid:x);` and `"cid:x",` don't pick up punctuation.
+  const pattern = /(?<![A-Za-z0-9/])cid:([^\s"'>);,]+)/gi;
 
   for (const match of email.html.matchAll(pattern)) {
     const ref = match[1];
@@ -159,10 +163,5 @@ export function findOrphanedCidRefs(email: ParsedEmail): string[] {
 }
 
 function stripAngleBrackets(id: string): string {
-  let s = id.trim();
-
-  if (s.startsWith("<")) s = s.slice(1);
-  if (s.endsWith(">")) s = s.slice(0, -1);
-
-  return s;
+  return id.trim().replace(/^<|>$/g, "");
 }

--- a/src/content.ts
+++ b/src/content.ts
@@ -95,3 +95,74 @@ export function isInlineAttachment(attachment: Attachment): boolean {
 export function listAttachments(email: ParsedEmail): Attachment[] {
   return email.attachments.filter((a) => !isInlineAttachment(a));
 }
+
+/**
+ * Find `cid:` references in the HTML body that are **not** backed by
+ * an inline attachment on the same email.
+ *
+ * Useful before forwarding or rendering: an orphaned `cid:` pointer
+ * will render as a broken image in the recipient's client because the
+ * referenced part was stripped by a relay, stored externally, or
+ * otherwise missing. Callers can rewrite them to data URIs / fallback
+ * placeholders, or log a warning.
+ *
+ * Returns a de-duplicated list of cid tokens (bare, no `cid:` prefix,
+ * no angle brackets) in first-seen order. An empty array means every
+ * `cid:` reference has a matching inline attachment.
+ *
+ * @param email The email to inspect.
+ * @returns Bare cid tokens referenced from `email.html` without a
+ * matching inline attachment.
+ *
+ * @example
+ * ```ts
+ * const orphans = findOrphanedCidRefs(email);
+ * if (orphans.length > 0) {
+ *   console.warn("forwarding with broken inline images:", orphans);
+ * }
+ * ```
+ */
+export function findOrphanedCidRefs(email: ParsedEmail): string[] {
+  if (!email.html) {
+    return [];
+  }
+
+  const backed = new Set<string>();
+
+  for (const att of email.attachments) {
+    if (!isInlineAttachment(att) || att.contentId === undefined) {
+      continue;
+    }
+
+    backed.add(stripAngleBrackets(att.contentId));
+  }
+
+  const orphans: string[] = [];
+  const seen = new Set<string>();
+  const pattern = /cid:([^\s"'>)]+)/gi;
+
+  for (const match of email.html.matchAll(pattern)) {
+    const ref = match[1];
+
+    if (!ref || seen.has(ref)) {
+      continue;
+    }
+
+    seen.add(ref);
+
+    if (!backed.has(ref)) {
+      orphans.push(ref);
+    }
+  }
+
+  return orphans;
+}
+
+function stripAngleBrackets(id: string): string {
+  let s = id.trim();
+
+  if (s.startsWith("<")) s = s.slice(1);
+  if (s.endsWith(">")) s = s.slice(0, -1);
+
+  return s;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,10 +40,18 @@ export {
   parseAddressList,
 } from "./addressing.ts";
 
-export { extractThreadingHeaders, parseMessage } from "./parsing.ts";
+export {
+  DEFAULT_MAX_ATTACHMENT_SIZE,
+  DEFAULT_MAX_BODY_SIZE,
+  DEFAULT_MAX_HEADER_SIZE,
+  extractThreadingHeaders,
+  parseMessage,
+} from "./parsing.ts";
+export type { ParseMessageOptions } from "./parsing.ts";
 
 export {
   extractBody,
+  findOrphanedCidRefs,
   isInlineAttachment,
   listAttachments,
 } from "./content.ts";

--- a/src/parsing.test.ts
+++ b/src/parsing.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { extractThreadingHeaders, parseMessage } from "./parsing.ts";
+import {
+  DEFAULT_MAX_ATTACHMENT_SIZE,
+  DEFAULT_MAX_BODY_SIZE,
+  DEFAULT_MAX_HEADER_SIZE,
+  extractThreadingHeaders,
+  parseMessage,
+} from "./parsing.ts";
 
 function eml(lines: ReadonlyArray<string>): string {
   return lines.join("\r\n");
@@ -618,5 +624,167 @@ describe("extractThreadingHeaders", () => {
     const email = await parseMessage(raw);
 
     expect(email.references.join(" ")).toBe(tokens.join(" "));
+  });
+});
+
+describe("parseMessage — defensive caps", () => {
+  it("exports sensible default constants", () => {
+    expect(DEFAULT_MAX_HEADER_SIZE).toBe(1_000_000);
+    expect(DEFAULT_MAX_ATTACHMENT_SIZE).toBe(5_000_000);
+    expect(DEFAULT_MAX_BODY_SIZE).toBe(50_000_000);
+  });
+
+  it("returns the full body and attachment when no caps are set", async () => {
+    const body = "a".repeat(4096);
+    const attachmentBody = "b".repeat(2048);
+    const raw = [
+      "From: ada@example.com",
+      "Subject: Plain",
+      "Content-Type: multipart/mixed; boundary=BOUND",
+      "",
+      "--BOUND",
+      "Content-Type: text/plain",
+      "",
+      body,
+      "--BOUND",
+      'Content-Type: application/octet-stream; name="data.bin"',
+      'Content-Disposition: attachment; filename="data.bin"',
+      "",
+      attachmentBody,
+      "--BOUND--",
+      "",
+    ].join("\r\n");
+
+    const email = await parseMessage(raw);
+
+    expect(email.text?.trim()).toBe(body);
+    expect(email.attachments[0]?.content).toBeDefined();
+  });
+
+  it("strips body parts whose UTF-8 byte length exceeds maxBodySize", async () => {
+    const body = "hello world";
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: Big",
+      "",
+      body,
+      "",
+    ]);
+
+    const email = await parseMessage(raw, { maxBodySize: 3 });
+
+    // Over-cap body is stripped; metadata (subject, from) survives.
+    expect(email.text).toBeUndefined();
+    expect(email.subject).toBe("Big");
+  });
+
+  it("keeps body parts whose UTF-8 byte length is within maxBodySize", async () => {
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: Ok",
+      "",
+      "tiny",
+      "",
+    ]);
+
+    const email = await parseMessage(raw, { maxBodySize: 1024 });
+
+    expect(email.text?.trim()).toBe("tiny");
+  });
+
+  it("counts body size in UTF-8 bytes, not characters", async () => {
+    // "£" is 2 bytes in UTF-8, 1 code unit in JS. "£££" = 6 bytes, 3 chars.
+    const body = "£££";
+    const raw = eml([
+      "From: ada@example.com",
+      "Subject: Utf",
+      'Content-Type: text/plain; charset="utf-8"',
+      "",
+      body,
+      "",
+    ]);
+
+    // A cap of 4 (bytes) should strip, even though length is 3.
+    const over = await parseMessage(raw, { maxBodySize: 4 });
+
+    expect(over.text).toBeUndefined();
+
+    // A cap of 8 (bytes) should keep.
+    const under = await parseMessage(raw, { maxBodySize: 8 });
+
+    expect(under.text?.trim()).toBe(body);
+  });
+
+  it("drops attachment content but preserves metadata when over maxAttachmentSize", async () => {
+    const attachmentBody = "x".repeat(1024);
+    const raw = [
+      "From: ada@example.com",
+      "Subject: Big attachment",
+      "Content-Type: multipart/mixed; boundary=BOUND",
+      "",
+      "--BOUND",
+      "Content-Type: text/plain",
+      "",
+      "note",
+      "--BOUND",
+      'Content-Type: application/octet-stream; name="data.bin"',
+      'Content-Disposition: attachment; filename="data.bin"',
+      "",
+      attachmentBody,
+      "--BOUND--",
+      "",
+    ].join("\r\n");
+
+    const email = await parseMessage(raw, { maxAttachmentSize: 256 });
+    const att = email.attachments[0];
+
+    expect(att).toBeDefined();
+    expect(att?.filename).toBe("data.bin");
+    expect(att?.size).toBeGreaterThan(256);
+    expect(att?.content).toBeUndefined();
+    // A later createForward would throw on this attachment, which is
+    // the point — caller opts in and inherits the contract.
+  });
+
+  it("keeps attachment content when within maxAttachmentSize", async () => {
+    const attachmentBody = "x".repeat(128);
+    const raw = [
+      "From: ada@example.com",
+      "Subject: Small attachment",
+      "Content-Type: multipart/mixed; boundary=BOUND",
+      "",
+      "--BOUND",
+      "Content-Type: text/plain",
+      "",
+      "note",
+      "--BOUND",
+      'Content-Type: application/octet-stream; name="data.bin"',
+      'Content-Disposition: attachment; filename="data.bin"',
+      "",
+      attachmentBody,
+      "--BOUND--",
+      "",
+    ].join("\r\n");
+
+    const email = await parseMessage(raw, { maxAttachmentSize: 1024 });
+
+    expect(email.attachments[0]?.content).toBeDefined();
+    expect(email.attachments[0]?.size).toBeGreaterThanOrEqual(128);
+    expect(email.attachments[0]?.size).toBeLessThanOrEqual(1024);
+  });
+
+  it("forwards maxHeaderSize to postal-mime, which throws on over-cap headers", async () => {
+    const padding = "a".repeat(200);
+    const raw = eml([
+      "From: ada@example.com",
+      `X-Big: ${padding}`,
+      "Subject: Hi",
+      "",
+      "body",
+      "",
+    ]);
+
+    // Tiny cap — postal-mime rejects the header block.
+    await expect(parseMessage(raw, { maxHeaderSize: 10 })).rejects.toThrow();
   });
 });

--- a/src/parsing.test.ts
+++ b/src/parsing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { createForward } from "./composition.ts";
 import {
   DEFAULT_MAX_ATTACHMENT_SIZE,
   DEFAULT_MAX_BODY_SIZE,
@@ -771,6 +772,121 @@ describe("parseMessage — defensive caps", () => {
     expect(email.attachments[0]?.content).toBeDefined();
     expect(email.attachments[0]?.size).toBeGreaterThanOrEqual(128);
     expect(email.attachments[0]?.size).toBeLessThanOrEqual(1024);
+  });
+
+  it("applies maxBodySize independently to html and text branches", async () => {
+    // Short text, very long html. The cap drops html but keeps text.
+    const shortText = "short";
+    const longHtml = `<p>${"x".repeat(2048)}</p>`;
+    const raw = [
+      "From: ada@example.com",
+      "Subject: Mixed",
+      "Content-Type: multipart/alternative; boundary=BOUND",
+      "",
+      "--BOUND",
+      "Content-Type: text/plain",
+      "",
+      shortText,
+      "--BOUND",
+      "Content-Type: text/html",
+      "",
+      longHtml,
+      "--BOUND--",
+      "",
+    ].join("\r\n");
+
+    const email = await parseMessage(raw, { maxBodySize: 256 });
+
+    expect(email.text?.trim()).toBe(shortText);
+    expect(email.html).toBeUndefined();
+
+    // Flip the sides: short html, long text → text stripped, html kept.
+    const shortHtml = "<p>hi</p>";
+    const longText = "y".repeat(2048);
+    const raw2 = [
+      "From: ada@example.com",
+      "Subject: Mixed",
+      "Content-Type: multipart/alternative; boundary=BOUND",
+      "",
+      "--BOUND",
+      "Content-Type: text/plain",
+      "",
+      longText,
+      "--BOUND",
+      "Content-Type: text/html",
+      "",
+      shortHtml,
+      "--BOUND--",
+      "",
+    ].join("\r\n");
+
+    const email2 = await parseMessage(raw2, { maxBodySize: 256 });
+
+    expect(email2.text).toBeUndefined();
+    expect(email2.html).toContain("<p>hi</p>");
+  });
+
+  it("preserves every attachment metadata field when content is stripped", async () => {
+    const attachmentBody = "z".repeat(1024);
+    const raw = [
+      "From: ada@example.com",
+      "Subject: inline big",
+      "Content-Type: multipart/related; boundary=BOUND",
+      "",
+      "--BOUND",
+      'Content-Type: text/html; charset="utf-8"',
+      "",
+      '<p><img src="cid:logo@x"></p>',
+      "--BOUND",
+      'Content-Type: image/png; name="logo.png"',
+      'Content-Disposition: inline; filename="logo.png"',
+      "Content-ID: <logo@x>",
+      "",
+      attachmentBody,
+      "--BOUND--",
+      "",
+    ].join("\r\n");
+
+    const email = await parseMessage(raw, { maxAttachmentSize: 256 });
+    const att = email.attachments[0]!;
+
+    expect(att.filename).toBe("logo.png");
+    expect(att.mimeType).toBe("image/png");
+    expect(att.disposition).toBe("inline");
+    expect(att.contentId).toBe("<logo@x>");
+    expect(att.size).toBeGreaterThan(256);
+    expect(att.content).toBeUndefined();
+  });
+
+  it("createForward surfaces the opt-in contract: stripped attachments throw as caller error", async () => {
+    const attachmentBody = "x".repeat(1024);
+    const raw = [
+      "From: ada@example.com",
+      "To: grace@example.com",
+      "Subject: Heavy",
+      "Content-Type: multipart/mixed; boundary=BOUND",
+      "",
+      "--BOUND",
+      "Content-Type: text/plain",
+      "",
+      "note",
+      "--BOUND",
+      'Content-Type: application/octet-stream; name="data.bin"',
+      'Content-Disposition: attachment; filename="data.bin"',
+      "",
+      attachmentBody,
+      "--BOUND--",
+      "",
+    ].join("\r\n");
+
+    const email = await parseMessage(raw, { maxAttachmentSize: 256 });
+
+    expect(() =>
+      createForward(email, {
+        from: { address: "bob@example.com" },
+        to: [{ address: "carol@example.com" }],
+      }),
+    ).toThrow(/createForward requires Attachment.content/);
   });
 
   it("forwards maxHeaderSize to postal-mime, which throws on over-cap headers", async () => {

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -201,7 +201,7 @@ function mapAttachment(
     disposition,
     contentId: att.contentId,
     size,
-    ...(keepContent && content !== undefined ? { content } : {}),
+    content: keepContent ? content : undefined,
   };
 }
 
@@ -236,7 +236,15 @@ function withinBodySize(
     return body;
   }
 
-  // UTF-8 byte length so multi-byte scripts don't slip past the cap.
+  // UTF-8 is at most 3 bytes per UTF-16 code unit for the BMP and up
+  // to 4 for surrogate pairs — averaged as 3 that's a safe upper
+  // bound. Skip the full encode for the common under-cap case so we
+  // don't allocate a 50 MB Uint8Array on a 50 MB body just to
+  // measure it.
+  if (body.length * 3 <= cap) {
+    return body;
+  }
+
   const bytes = new TextEncoder().encode(body).byteLength;
 
   return bytes <= cap ? body : undefined;

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -26,6 +26,57 @@ import type {
   ThreadingHeaders,
 } from "./types.ts";
 
+/**
+ * Suggested default cap on the combined size of the header block,
+ * in bytes. Not applied automatically — pass as
+ * {@link ParseMessageOptions.maxHeaderSize} when you want it.
+ *
+ * Mirrors emailengine's baseline (1 MB). Roomy enough for 10+-hop
+ * Received chains and duplicate DKIM-Signatures; tight enough to
+ * reject pathological header-stuffing attacks.
+ */
+export const DEFAULT_MAX_HEADER_SIZE = 1_000_000;
+
+/**
+ * Suggested default cap on a single attachment's decoded payload, in
+ * bytes. Not applied automatically — pass as
+ * {@link ParseMessageOptions.maxAttachmentSize} when you want it.
+ *
+ * Mirrors emailengine's baseline (5 MB).
+ */
+export const DEFAULT_MAX_ATTACHMENT_SIZE = 5_000_000;
+
+/**
+ * Suggested default cap on a single body part's (html or text) byte
+ * length. Not applied automatically — pass as
+ * {@link ParseMessageOptions.maxBodySize} when you want it.
+ *
+ * Mirrors emailengine's baseline (50 MB).
+ */
+export const DEFAULT_MAX_BODY_SIZE = 50_000_000;
+
+/**
+ * Opt-in caps that protect constrained runtimes (Workers, edge
+ * functions) from OOMing on a single pathological email.
+ *
+ * None are enforced by default — set only what you need. `parseMessage`
+ * never throws when a cap is exceeded: it strips the over-size payload
+ * and preserves the metadata (e.g. `Attachment.size`), so the caller
+ * can still see that a part existed and decide how to react.
+ *
+ * @see {@link DEFAULT_MAX_HEADER_SIZE}
+ * @see {@link DEFAULT_MAX_ATTACHMENT_SIZE}
+ * @see {@link DEFAULT_MAX_BODY_SIZE}
+ */
+export type ParseMessageOptions = {
+  /** Byte cap for the combined header block; forwarded to postal-mime. */
+  readonly maxHeaderSize?: number | undefined;
+  /** Byte cap for a single attachment's decoded payload. Over-cap attachments come back with `content` undefined. */
+  readonly maxAttachmentSize?: number | undefined;
+  /** Byte cap for a single body part (`html` or `text`). Over-cap bodies come back `undefined`. */
+  readonly maxBodySize?: number | undefined;
+};
+
 function mapMailbox(mailbox: PMMailbox): EmailAddress {
   const trimmed = mailbox.name?.trim();
 
@@ -130,11 +181,19 @@ function toArrayBuffer(
   return content;
 }
 
-function mapAttachment(att: PMAttachment): Attachment {
+function mapAttachment(
+  att: PMAttachment,
+  maxAttachmentSize: number | undefined,
+): Attachment {
   const content = toArrayBuffer(att.content);
   const size = content?.byteLength ?? 0;
   const disposition: "attachment" | "inline" =
     att.disposition === "inline" ? "inline" : "attachment";
+  // Strip oversized payloads rather than throwing — preserves metadata
+  // (filename, size) so the caller can surface "attachment too large"
+  // without paying the memory cost.
+  const keepContent =
+    maxAttachmentSize === undefined || size <= maxAttachmentSize;
 
   return {
     filename: att.filename ?? undefined,
@@ -142,7 +201,7 @@ function mapAttachment(att: PMAttachment): Attachment {
     disposition,
     contentId: att.contentId,
     size,
-    content,
+    ...(keepContent && content !== undefined ? { content } : {}),
   };
 }
 
@@ -169,7 +228,26 @@ function buildHeaders(list: PMHeader[] | undefined): Map<string, string[]> {
   return map;
 }
 
-function toParsedEmail(p: PMEmail): ParsedEmail {
+function withinBodySize(
+  body: string | undefined,
+  cap: number | undefined,
+): string | undefined {
+  if (body === undefined || cap === undefined) {
+    return body;
+  }
+
+  // UTF-8 byte length so multi-byte scripts don't slip past the cap.
+  const bytes = new TextEncoder().encode(body).byteLength;
+
+  return bytes <= cap ? body : undefined;
+}
+
+function toParsedEmail(p: PMEmail, options: ParseMessageOptions): ParsedEmail {
+  const maxAttachmentSize = options.maxAttachmentSize;
+  const maxBodySize = options.maxBodySize;
+  const html = withinBodySize(p.html, maxBodySize);
+  const text = withinBodySize(p.text, maxBodySize);
+
   return {
     messageId: p.messageId,
     inReplyTo: p.inReplyTo,
@@ -181,9 +259,11 @@ function toParsedEmail(p: PMEmail): ParsedEmail {
     bcc: flattenAddresses(p.bcc),
     replyTo: firstAddress(p.replyTo),
     date: parseDate(p.date),
-    html: p.html,
-    text: p.text,
-    attachments: (p.attachments ?? []).map(mapAttachment),
+    html,
+    text,
+    attachments: (p.attachments ?? []).map((a) =>
+      mapAttachment(a, maxAttachmentSize),
+    ),
     headers: buildHeaders(p.headers),
   };
 }
@@ -197,29 +277,41 @@ function toParsedEmail(p: PMEmail): ParsedEmail {
  * `undefined`, empty collections become `[]`, and an unparseable `Date:`
  * header yields `undefined`.
  *
+ * Opt-in caps via {@link ParseMessageOptions} protect constrained
+ * runtimes from OOMing on pathological input — see
+ * {@link DEFAULT_MAX_HEADER_SIZE}, {@link DEFAULT_MAX_ATTACHMENT_SIZE},
+ * {@link DEFAULT_MAX_BODY_SIZE} for sensible defaults.
+ *
  * @param raw The email source.
+ * @param options Optional caps on header / body / attachment size.
  * @returns A structured {@link ParsedEmail}.
  * @throws {Error} When `raw` is not recognizable MIME and `postal-mime`
  * cannot produce a parse tree (corrupt envelope, truncated multipart,
- * etc.). Per-field issues do **not** throw.
+ * etc.), or when `options.maxHeaderSize` is set and the header block
+ * exceeds it (postal-mime enforces). Per-field issues do **not** throw.
  *
  * @example
  * ```ts
- * import { parseMessage } from "@oflabs/mail-utils";
+ * import { parseMessage, DEFAULT_MAX_ATTACHMENT_SIZE } from "@oflabs/mail-utils";
  *
  * declare const rawEml: string;
- * const email = await parseMessage(rawEml);
- * const { to, from, subject } = email;
+ * const email = await parseMessage(rawEml, {
+ *   maxAttachmentSize: DEFAULT_MAX_ATTACHMENT_SIZE,
+ * });
  * ```
  */
 export async function parseMessage(
   raw: string | ArrayBuffer,
+  options: ParseMessageOptions = {},
 ): Promise<ParsedEmail> {
   const parsed = await PostalMime.parse(raw, {
     attachmentEncoding: "arraybuffer",
+    ...(options.maxHeaderSize !== undefined
+      ? { maxHeadersSize: options.maxHeaderSize }
+      : {}),
   });
 
-  return toParsedEmail(parsed);
+  return toParsedEmail(parsed, options);
 }
 
 /**


### PR DESCRIPTION
## Summary

Two defensive additions for people running this library in constrained places (Workers, edge functions) or sending email with broken inline images.

- `parseMessage` now takes an optional caps object. If you're worried about a single giant email OOMing your worker, tell it the maximum header, attachment, and body size you're willing to handle. Over-cap attachments still report their metadata (filename, size) so you can show "attachment too large" — only the bytes are dropped. Nothing changes for callers that don't opt in.
- `findOrphanedCidRefs(email)` tells you which `cid:` images in the HTML body won't render because the attachment they point to isn't there. Useful before forwarding or rendering so you can rewrite to a placeholder or log a warning, rather than shipping a broken image.

Closes #15

## Test plan
- [x] `make typecheck` passes
- [x] `make test` — all 288 tests pass (21 new)
- [x] `make publish-jsr-dry` — clean