### PR TITLE
Rename package to @oflabs/email-utils

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — @oflabs/mail-utils
+# CLAUDE.md — @oflabs/email-utils
 
 Platform-agnostic TS utility library for email parsing, threading, composition. Runs in Workers, Node, Deno, Bun, browsers. No I/O, no storage, no platform bindings.
 
@@ -6,7 +6,7 @@ Platform-agnostic TS utility library for email parsing, threading, composition. 
 
 - **[PRD.md](./PRD.md)** is the authoritative spec. Read it before implementing anything.
 - Spec decisions from the /grll-me interview live in `~/.claude/projects/-Users-oladayo-fagbemi-code-oflabs-email-utils/memory/` — check MEMORY.md for the index. Do not re-litigate decisions captured there.
-- GitHub issues tagged `prd/mail-utils-v1` = the work queue. Issues 1–8.
+- GitHub issues tagged `prd/email-utils-v1` = the work queue. Issues 1–8.
 
 ## Design rules (non-negotiable)
 
@@ -21,7 +21,7 @@ Platform-agnostic TS utility library for email parsing, threading, composition. 
 
 ## Publishing
 
-- JSR only at `@oflabs/mail-utils`. No npm, no `dist/`, no build step.
+- JSR only at `@oflabs/email-utils`. No npm, no `dist/`, no build step.
 - `tsconfig.json` has `noEmit: true` — tsc is type-check only. JSR consumes raw `.ts`.
 - Release: bump `jsr.json` version → commit → `git tag v0.x.y && git push --tags` → OIDC-authenticated GitHub Actions publishes.
 - Local dry-run: `make publish-jsr-dry`. Catches slow-types before CI.

--- a/PRD.md
+++ b/PRD.md
@@ -1,6 +1,6 @@
-# PRD: `mail-utils` — Platform-agnostic Email Utility Library
+# PRD: `email-utils` — Platform-agnostic Email Utility Library
 
-**PRD slug:** `prd/mail-utils-v1`
+**PRD slug:** `prd/email-utils-v1`
 
 ---
 
@@ -12,7 +12,7 @@ There is no TypeScript library today that is (a) genuinely platform-agnostic, (b
 
 ## Solution
 
-A single TypeScript utility package — `mail-utils` — with named-export, pure-function APIs for parsing, threading, composition, addressing, and content inspection. Zero I/O, zero platform bindings, zero Node built-ins. Runs unchanged in Cloudflare Workers, Node, Deno, Bun, browsers, and test runners. Every function is synchronous except `parseMessage`. Every behavior is documented, tested against a corpus of real-world gnarly emails, and free of silent data loss (no dropped headers, no lost attachments, no BCC leaks, no thread truncation).
+A single TypeScript utility package — `email-utils` — with named-export, pure-function APIs for parsing, threading, composition, addressing, and content inspection. Zero I/O, zero platform bindings, zero Node built-ins. Runs unchanged in Cloudflare Workers, Node, Deno, Bun, browsers, and test runners. Every function is synchronous except `parseMessage`. Every behavior is documented, tested against a corpus of real-world gnarly emails, and free of silent data loss (no dropped headers, no lost attachments, no BCC leaks, no thread truncation).
 
 ## User Stories
 
@@ -123,7 +123,7 @@ A single TypeScript utility package — `mail-utils` — with named-export, pure
 
 ### Publishing
 
-- Registry: **JSR only** at `@oflabs/mail-utils`. No npm. No built `dist/`.
+- Registry: **JSR only** at `@oflabs/email-utils`. No npm. No built `dist/`.
 - `jsr.json` is the publish manifest; `exports` points at `./src/index.ts`.
 - Authenticated release via GitHub Actions OIDC (`id-token: write`) triggered on `v*` tag push.
 - Local dry-run: `make publish-jsr-dry`. Local real publish (if ever needed): `make publish-jsr`, which interactively authenticates.
@@ -184,6 +184,6 @@ A single TypeScript utility package — `mail-utils` — with named-export, pure
 ## Further Notes
 
 - **Versioning:** v1.0.0 is this release. Breaking changes in types (`headers` shape, `Attachment.content` optionality, `ThreadNode` shape) are intentional; no earlier version exists to break.
-- **Package structure:** a single package at repo root is simpler than the `packages/mail-utils/` nested layout in the original spec unless a monorepo materializes. Use the flat layout; revisit if multiple packages emerge.
+- **Package structure:** a single package at repo root is simpler than the `packages/email-utils/` nested layout in the original spec unless a monorepo materializes. Use the flat layout; revisit if multiple packages emerge.
 - **Backwards-compat with the original spec:** the resolved decisions intentionally diverge from the literal text of the original spec where it was under-specified or contradictory. The decisions here are authoritative.
 - **Docs:** a `README.md` with a one-liner per function and a usage example per module is in scope. Extended API docs can be generated from TSDoc later; not blocking v1.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @oflabs/mail-utils
+# @oflabs/email-utils
 
 Platform-agnostic TypeScript utilities for email parsing, threading, and composition.
 
@@ -8,14 +8,14 @@ Runs unchanged in Cloudflare Workers, Node.js, Deno, Bun, browsers, and any test
 
 ## Install
 
-Published on [JSR](https://jsr.io/@oflabs/mail-utils).
+Published on [JSR](https://jsr.io/@oflabs/email-utils).
 
 ```sh
-deno add jsr:@oflabs/mail-utils
+deno add jsr:@oflabs/email-utils
 # or
-pnpm dlx jsr add @oflabs/mail-utils
+pnpm dlx jsr add @oflabs/email-utils
 # or
-bunx jsr add @oflabs/mail-utils
+bunx jsr add @oflabs/email-utils
 ```
 
 ## Modules

--- a/jsr.json
+++ b/jsr.json
@@ -1,5 +1,5 @@
 {
-  "name": "@oflabs/mail-utils",
+  "name": "@oflabs/email-utils",
   "version": "0.1.0",
   "license": "MIT",
   "exports": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "@oflabs/mail-utils",
+  "name": "@oflabs/email-utils",
   "version": "0.1.0",
   "private": true,
   "description": "Platform-agnostic TypeScript utilities for email parsing, threading, and composition. Published on JSR.",
   "license": "MIT",
-  "author": "Oladayo Fagbemi (https://github.com/oladayo21)",
+  "author": "Oladayo Fagbemi (https://github.com/oflabs44)",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/oladayo21/mail-utils.git"
+    "url": "git+https://github.com/oflabs44/email-utils.git"
   },
   "bugs": {
-    "url": "https://github.com/oladayo21/mail-utils/issues"
+    "url": "https://github.com/oflabs44/email-utils/issues"
   },
-  "homepage": "https://github.com/oladayo21/mail-utils#readme",
+  "homepage": "https://github.com/oflabs44/email-utils#readme",
   "type": "module",
   "scripts": {
     "test": "vitest run",

--- a/src/addressing.ts
+++ b/src/addressing.ts
@@ -6,7 +6,7 @@
  *
  * @example
  * ```ts
- * import { parseAddressList, formatAddress } from "@oflabs/mail-utils";
+ * import { parseAddressList, formatAddress } from "@oflabs/email-utils";
  *
  * const addrs = parseAddressList('"Alice" <alice@example.com>, bob@example.com');
  * addrs.map(formatAddress).join(", ");

--- a/src/composition.ts
+++ b/src/composition.ts
@@ -10,7 +10,7 @@
  *
  * @example
  * ```ts
- * import { createReply, parseMessage } from "@oflabs/mail-utils";
+ * import { createReply, parseMessage } from "@oflabs/email-utils";
  *
  * declare const rawEml: string;
  * const incoming = await parseMessage(rawEml);

--- a/src/content.ts
+++ b/src/content.ts
@@ -10,7 +10,7 @@
  *   extractBody,
  *   listAttachments,
  *   isInlineAttachment,
- * } from "@oflabs/mail-utils";
+ * } from "@oflabs/email-utils";
  *
  * const body = extractBody(email);        // { html?, text? }
  * const files = listAttachments(email);   // user-facing attachments only

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,11 @@
  * Platform-agnostic TypeScript utilities for email. Shipped modules so
  * far: address parsing, formatting, validation, and list utilities.
  * Parsing, threading, and composition modules are planned — track
- * progress at https://github.com/oladayo21/mail-utils/issues.
+ * progress at https://github.com/oflabs44/email-utils/issues.
  *
  * @example
  * ```ts
- * import { parseAddressList, formatAddress } from "@oflabs/mail-utils";
+ * import { parseAddressList, formatAddress } from "@oflabs/email-utils";
  *
  * const addrs = parseAddressList(
  *   "Ada <ada@example.com>, Grace <grace@example.com>",

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -300,7 +300,7 @@ function toParsedEmail(p: PMEmail, options: ParseMessageOptions): ParsedEmail {
  *
  * @example
  * ```ts
- * import { parseMessage, DEFAULT_MAX_ATTACHMENT_SIZE } from "@oflabs/mail-utils";
+ * import { parseMessage, DEFAULT_MAX_ATTACHMENT_SIZE } from "@oflabs/email-utils";
  *
  * declare const rawEml: string;
  * const email = await parseMessage(rawEml, {

--- a/src/threading.ts
+++ b/src/threading.ts
@@ -5,7 +5,7 @@
  *
  * @example
  * ```ts
- * import { buildThreads, parseMessage } from "@oflabs/mail-utils";
+ * import { buildThreads, parseMessage } from "@oflabs/email-utils";
  *
  * const emails = await Promise.all(rawEmls.map(parseMessage));
  * const threads = buildThreads(emails);
@@ -64,7 +64,7 @@ export function normalizeSubject(subject: string): string {
  *
  * @example
  * ```ts
- * import { getThreadId, isOrphanId } from "@oflabs/mail-utils";
+ * import { getThreadId, isOrphanId } from "@oflabs/email-utils";
  *
  * declare const email: ParsedEmail;
  * const id = getThreadId(email);
@@ -112,7 +112,7 @@ export function getThreadId(email: ParsedEmail): string {
  *
  * @example
  * ```ts
- * import { buildThreads, parseMessage } from "@oflabs/mail-utils";
+ * import { buildThreads, parseMessage } from "@oflabs/email-utils";
  *
  * declare const raws: string[];
  * const emails = await Promise.all(raws.map(parseMessage));
@@ -158,7 +158,7 @@ export function buildThreads(
  *
  * @example
  * ```ts
- * import { ingestIntoThreads } from "@oflabs/mail-utils";
+ * import { ingestIntoThreads } from "@oflabs/email-utils";
  *
  * let threads: Thread[] = [];
  *


### PR DESCRIPTION
## Summary

The repo on GitHub is called `email-utils` but the package was named `@oflabs/mail-utils`. Split naming was confusing every time I looked at README, labels, or import paths. Unifying on `email-utils` everywhere so the name means one thing.

Nothing has been published to JSR yet (pre-v1, no tags), so this is free to do now with no downstream break.

## Test plan
- [x] `make typecheck` passes
- [x] `make test` — 292 tests pass
- [x] `make publish-jsr-dry` — clean
- [x] GitHub label renamed: `prd/mail-utils-v1` → `prd/email-utils-v1`
- [x] Stale `oladayo21/mail-utils` GitHub links in `package.json` and `src/index.ts` fixed to `oflabs44/email-utils`