### PR TITLE
Wire up JSR publish workflow for v0.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
 

--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -16,8 +16,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:
@@ -26,8 +24,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm typecheck
+      - run: make typecheck
 
-      - run: pnpm test
+      - run: make test
 
-      - run: pnpm publish:jsr
+      - run: make publish-jsr

--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,9 @@ Platform-agnostic TS utility library for email parsing, threading, composition. 
 
 - JSR only at `@oflabs/email-utils`. No npm, no `dist/`, no build step.
 - `tsconfig.json` has `noEmit: true` — tsc is type-check only. JSR consumes raw `.ts`.
-- Release: bump `jsr.json` version → commit → `git tag v0.x.y && git push --tags` → OIDC-authenticated GitHub Actions publishes.
-- Local dry-run: `make publish-jsr-dry`. Catches slow-types before CI.
+- Release: bump `jsr.json` version (and `package.json` to match) → commit → `git tag v0.x.y && git push --tags` → `.github/workflows/publish-jsr.yml` runs on the `v*` tag, authenticates via GitHub Actions OIDC (no `JSR_API_KEY` secret), and publishes.
+- Local dry-run: `make publish-jsr-dry`. Catches slow-types before CI. Also runs in `.github/workflows/ci.yml` on every PR.
+- **One-time scope setup (already done / redo if the scope is ever deleted):** create `@oflabs` at <https://jsr.io/new>, link to the `oflabs44` GitHub account, and grant publish permission to `oflabs44/email-utils`. After that, publishes are fully automated by tag.
 
 ## Per-issue workflow
 


### PR DESCRIPTION
## Summary

We had a JSR publish workflow scaffolded but it would have failed the same way CI did — the pnpm action was pinned to version 10 while `package.json` already declared the exact pnpm version via `packageManager`, which fights the action. This fixes that, routes the workflow's commands through `make` so local and CI go through the same entry points, and writes down the one-time JSR scope setup step in `CLAUDE.md` so it's not lost the next time I come back to this.

After this merges, a `v0.1.0` tag push will publish to JSR.

## Test plan
- [x] `make typecheck` passes
- [x] `make test` — 292 tests pass
- [x] `jsr publish --dry-run` — clean, no slow-types, no doc warnings
- [ ] One-time: create `@oflabs` scope at <https://jsr.io/new> and grant publish permission to `oflabs44/email-utils` (manual, before first tag)

Closes #7